### PR TITLE
Add SimpliSafe camera plugin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,15 @@
 {
-   "name": "@scrypted/vscode-typescript",
+   "name": "@scrypted/simplisafe",
    "lockfileVersion": 2,
    "requires": true,
    "packages": {
       "": {
-         "name": "@scrypted/vscode-typescript",
+         "name": "@scrypted/simplisafe",
          "dependencies": {
-            "@scrypted/sdk": "^0.5.29"
+            "@scrypted/sdk": "^0.5.29",
+            "axios": "^1.7.7",
+            "axios-retry": "^3.9.1",
+            "jpeg-extract": "^3.0.1"
          },
          "devDependencies": {
             "@types/node": "^24.0.10"
@@ -398,6 +401,15 @@
          },
          "peerDependencies": {
             "@babel/core": "^7.0.0-0"
+         }
+      },
+      "node_modules/@babel/runtime": {
+         "version": "7.28.4",
+         "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.4.tgz",
+         "integrity": "sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==",
+         "license": "MIT",
+         "engines": {
+            "node": ">=6.9.0"
          }
       },
       "node_modules/@babel/template": {
@@ -1265,10 +1277,43 @@
             "url": "https://github.com/chalk/ansi-styles?sponsor=1"
          }
       },
+      "node_modules/asn1": {
+         "version": "0.2.6",
+         "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
+         "integrity": "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==",
+         "license": "MIT",
+         "dependencies": {
+            "safer-buffer": "~2.1.0"
+         }
+      },
+      "node_modules/assert-plus": {
+         "version": "1.0.0",
+         "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+         "integrity": "sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==",
+         "license": "MIT",
+         "engines": {
+            "node": ">=0.8"
+         }
+      },
       "node_modules/asynckit": {
          "version": "0.4.0",
          "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
          "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+         "license": "MIT"
+      },
+      "node_modules/aws-sign2": {
+         "version": "0.7.0",
+         "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+         "integrity": "sha512-08kcGqnYf/YmjoRhfxyu+CLxBjUtHLXLXX/vUfx9l2LYzG3c1m61nrpyFUZI6zeS+Li/wWMMidD9KgrqtGq3mA==",
+         "license": "Apache-2.0",
+         "engines": {
+            "node": "*"
+         }
+      },
+      "node_modules/aws4": {
+         "version": "1.13.2",
+         "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.13.2.tgz",
+         "integrity": "sha512-lHe62zvbTB5eEABUVi/AwVh0ZKY9rMMDhmm+eeyuuUQbQ3+J+fONVQOZyj+DdrvD4BY33uYniyRJ4UJIaSKAfw==",
          "license": "MIT"
       },
       "node_modules/axios": {
@@ -1280,6 +1325,16 @@
             "follow-redirects": "^1.15.6",
             "form-data": "^4.0.0",
             "proxy-from-env": "^1.1.0"
+         }
+      },
+      "node_modules/axios-retry": {
+         "version": "3.9.1",
+         "resolved": "https://registry.npmjs.org/axios-retry/-/axios-retry-3.9.1.tgz",
+         "integrity": "sha512-8PJDLJv7qTTMMwdnbMvrLYuvB47M81wRtxQmEdV5w4rgbTXTt+vtPkXwajOfOdSyv/wZICJOC+/UhXH4aQ/R+w==",
+         "license": "Apache-2.0",
+         "dependencies": {
+            "@babel/runtime": "^7.15.4",
+            "is-retry-allowed": "^2.2.0"
          }
       },
       "node_modules/babel-loader": {
@@ -1317,6 +1372,15 @@
          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
          "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
          "license": "MIT"
+      },
+      "node_modules/bcrypt-pbkdf": {
+         "version": "1.0.2",
+         "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+         "integrity": "sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==",
+         "license": "BSD-3-Clause",
+         "dependencies": {
+            "tweetnacl": "^0.14.3"
+         }
       },
       "node_modules/big.js": {
          "version": "5.2.2",
@@ -1434,6 +1498,12 @@
          ],
          "license": "CC-BY-4.0"
       },
+      "node_modules/caseless": {
+         "version": "0.12.0",
+         "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+         "integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==",
+         "license": "Apache-2.0"
+      },
       "node_modules/chalk": {
          "version": "4.1.2",
          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -1508,6 +1578,12 @@
          "license": "MIT",
          "peer": true
       },
+      "node_modules/core-util-is": {
+         "version": "1.0.2",
+         "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+         "integrity": "sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==",
+         "license": "MIT"
+      },
       "node_modules/cross-spawn": {
          "version": "7.0.6",
          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -1520,6 +1596,18 @@
          },
          "engines": {
             "node": ">= 8"
+         }
+      },
+      "node_modules/dashdash": {
+         "version": "1.14.1",
+         "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+         "integrity": "sha512-jRFi8UDGo6j+odZiEpjazZaWqEal3w/basFjQHQEwVtZJGDpxbH1MeYluwCS8Xq5wmLJooDlMgvVarmWfGM44g==",
+         "license": "MIT",
+         "dependencies": {
+            "assert-plus": "^1.0.0"
+         },
+         "engines": {
+            "node": ">=0.10"
          }
       },
       "node_modules/debounce": {
@@ -1588,6 +1676,16 @@
          "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
          "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
          "license": "MIT"
+      },
+      "node_modules/ecc-jsbn": {
+         "version": "0.1.2",
+         "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+         "integrity": "sha512-eh9O+hwRHNbG4BLTjEl3nw044CkGm5X6LoaCf7LPp7UU8Qrt47JYNi6nPX8xjW97TKGKm1ouctg0QSpZe9qrnw==",
+         "license": "MIT",
+         "dependencies": {
+            "jsbn": "~0.1.0",
+            "safer-buffer": "^2.1.0"
+         }
       },
       "node_modules/electron-to-chromium": {
          "version": "1.5.115",
@@ -1753,6 +1851,21 @@
             "node": ">=0.8.x"
          }
       },
+      "node_modules/extend": {
+         "version": "3.0.2",
+         "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+         "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+         "license": "MIT"
+      },
+      "node_modules/extsprintf": {
+         "version": "1.3.0",
+         "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+         "integrity": "sha512-11Ndz7Nv+mvAC1j0ktTa7fAb0vLyGGX+rMHNBYQviQDGU0Hw7lhctJANqbPhu9nV9/izT/IntTgZ7Im/9LJs9g==",
+         "engines": [
+            "node >=0.6.0"
+         ],
+         "license": "MIT"
+      },
       "node_modules/fast-deep-equal": {
          "version": "3.1.3",
          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -1859,6 +1972,15 @@
             "url": "https://github.com/sponsors/isaacs"
          }
       },
+      "node_modules/forever-agent": {
+         "version": "0.6.1",
+         "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+         "integrity": "sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw==",
+         "license": "Apache-2.0",
+         "engines": {
+            "node": "*"
+         }
+      },
       "node_modules/form-data": {
          "version": "4.0.3",
          "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.3.tgz",
@@ -1945,6 +2067,15 @@
             "node": ">= 0.4"
          }
       },
+      "node_modules/getpass": {
+         "version": "0.1.7",
+         "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+         "integrity": "sha512-0fzj9JxOLfJ+XGLhR8ze3unN0KZCgZwiSSDz168VERjK8Wl8kVSdcu2kspd4s4wtAa1y/qrVRiAA0WclVsu0ng==",
+         "license": "MIT",
+         "dependencies": {
+            "assert-plus": "^1.0.0"
+         }
+      },
       "node_modules/glob": {
          "version": "11.0.1",
          "resolved": "https://registry.npmjs.org/glob/-/glob-11.0.1.tgz",
@@ -2007,6 +2138,51 @@
             "url": "https://github.com/sponsors/sindresorhus"
          }
       },
+      "node_modules/har-schema": {
+         "version": "2.0.0",
+         "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+         "integrity": "sha512-Oqluz6zhGX8cyRaTQlFMPw80bSJVG2x/cFb8ZPhUILGgHka9SsokCCOQgpveePerqidZOrT14ipqfJb7ILcW5Q==",
+         "license": "ISC",
+         "engines": {
+            "node": ">=4"
+         }
+      },
+      "node_modules/har-validator": {
+         "version": "5.1.5",
+         "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
+         "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
+         "deprecated": "this library is no longer supported",
+         "license": "MIT",
+         "dependencies": {
+            "ajv": "^6.12.3",
+            "har-schema": "^2.0.0"
+         },
+         "engines": {
+            "node": ">=6"
+         }
+      },
+      "node_modules/har-validator/node_modules/ajv": {
+         "version": "6.12.6",
+         "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+         "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+         "license": "MIT",
+         "dependencies": {
+            "fast-deep-equal": "^3.1.1",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.4.1",
+            "uri-js": "^4.2.2"
+         },
+         "funding": {
+            "type": "github",
+            "url": "https://github.com/sponsors/epoberezkin"
+         }
+      },
+      "node_modules/har-validator/node_modules/json-schema-traverse": {
+         "version": "0.4.1",
+         "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+         "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+         "license": "MIT"
+      },
       "node_modules/has-flag": {
          "version": "4.0.0",
          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -2061,6 +2237,21 @@
          "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
          "license": "MIT"
       },
+      "node_modules/http-signature": {
+         "version": "1.2.0",
+         "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+         "integrity": "sha512-CAbnr6Rz4CYQkLYUtSNXxQPUH2gK8f3iWexVlsnMeD+GjlsQ0Xsy1cOX+mN3dtxYomRy21CiOzU8Uhw6OwncEQ==",
+         "license": "MIT",
+         "dependencies": {
+            "assert-plus": "^1.0.0",
+            "jsprim": "^1.2.2",
+            "sshpk": "^1.7.0"
+         },
+         "engines": {
+            "node": ">=0.8",
+            "npm": ">=1.3.7"
+         }
+      },
       "node_modules/is-core-module": {
          "version": "2.16.1",
          "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
@@ -2109,11 +2300,35 @@
             "@types/estree": "*"
          }
       },
+      "node_modules/is-retry-allowed": {
+         "version": "2.2.0",
+         "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-2.2.0.tgz",
+         "integrity": "sha512-XVm7LOeLpTW4jV19QSH38vkswxoLud8sQ57YwJVTPWdiaI9I8keEhGFpBlslyVsgdQy4Opg8QOLb8YRgsyZiQg==",
+         "license": "MIT",
+         "engines": {
+            "node": ">=10"
+         },
+         "funding": {
+            "url": "https://github.com/sponsors/sindresorhus"
+         }
+      },
+      "node_modules/is-typedarray": {
+         "version": "1.0.0",
+         "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+         "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==",
+         "license": "MIT"
+      },
       "node_modules/isexe": {
          "version": "2.0.0",
          "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
          "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
          "license": "ISC"
+      },
+      "node_modules/isstream": {
+         "version": "0.1.2",
+         "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+         "integrity": "sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==",
+         "license": "MIT"
       },
       "node_modules/jackspeak": {
          "version": "4.1.0",
@@ -2159,10 +2374,25 @@
             "url": "https://github.com/chalk/supports-color?sponsor=1"
          }
       },
+      "node_modules/jpeg-extract": {
+         "version": "3.0.1",
+         "resolved": "https://registry.npmjs.org/jpeg-extract/-/jpeg-extract-3.0.1.tgz",
+         "integrity": "sha512-tCBe2CjnmsUPLVjXWj5r0Q7KDepWHlgL42U2N0/dokjkiyQOGb3HwI7vYL1t53Vnj80YOYNuz8oKSbUrHqgrFw==",
+         "license": "MIT",
+         "dependencies": {
+            "request": "^2.88.0"
+         }
+      },
       "node_modules/js-tokens": {
          "version": "4.0.0",
          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
          "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+         "license": "MIT"
+      },
+      "node_modules/jsbn": {
+         "version": "0.1.1",
+         "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+         "integrity": "sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg==",
          "license": "MIT"
       },
       "node_modules/jsesc": {
@@ -2183,11 +2413,23 @@
          "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
          "license": "MIT"
       },
+      "node_modules/json-schema": {
+         "version": "0.4.0",
+         "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+         "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
+         "license": "(AFL-2.1 OR BSD-3-Clause)"
+      },
       "node_modules/json-schema-traverse": {
          "version": "1.0.0",
          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
          "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
          "license": "MIT"
+      },
+      "node_modules/json-stringify-safe": {
+         "version": "5.0.1",
+         "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+         "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
+         "license": "ISC"
       },
       "node_modules/json5": {
          "version": "2.2.3",
@@ -2199,6 +2441,21 @@
          },
          "engines": {
             "node": ">=6"
+         }
+      },
+      "node_modules/jsprim": {
+         "version": "1.4.2",
+         "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.2.tgz",
+         "integrity": "sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==",
+         "license": "MIT",
+         "dependencies": {
+            "assert-plus": "1.0.0",
+            "extsprintf": "1.3.0",
+            "json-schema": "0.4.0",
+            "verror": "1.10.0"
+         },
+         "engines": {
+            "node": ">=0.6.0"
          }
       },
       "node_modules/loader-runner": {
@@ -2382,6 +2639,15 @@
          "integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==",
          "license": "MIT"
       },
+      "node_modules/oauth-sign": {
+         "version": "0.9.0",
+         "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
+         "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
+         "license": "Apache-2.0",
+         "engines": {
+            "node": "*"
+         }
+      },
       "node_modules/openai": {
          "version": "5.8.2",
          "resolved": "https://registry.npmjs.org/openai/-/openai-5.8.2.tgz",
@@ -2497,6 +2763,12 @@
             "node": "20 || >=22"
          }
       },
+      "node_modules/performance-now": {
+         "version": "2.1.0",
+         "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+         "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==",
+         "license": "MIT"
+      },
       "node_modules/picocolors": {
          "version": "1.1.1",
          "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -2521,6 +2793,18 @@
          "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
          "license": "MIT"
       },
+      "node_modules/psl": {
+         "version": "1.15.0",
+         "resolved": "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz",
+         "integrity": "sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==",
+         "license": "MIT",
+         "dependencies": {
+            "punycode": "^2.3.1"
+         },
+         "funding": {
+            "url": "https://github.com/sponsors/lupomontero"
+         }
+      },
       "node_modules/punycode": {
          "version": "2.3.1",
          "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -2528,6 +2812,15 @@
          "license": "MIT",
          "engines": {
             "node": ">=6"
+         }
+      },
+      "node_modules/qs": {
+         "version": "6.5.3",
+         "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.3.tgz",
+         "integrity": "sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA==",
+         "license": "BSD-3-Clause",
+         "engines": {
+            "node": ">=0.6"
          }
       },
       "node_modules/randombytes": {
@@ -2606,6 +2899,52 @@
          "funding": {
             "type": "opencollective",
             "url": "https://opencollective.com/webpack"
+         }
+      },
+      "node_modules/request": {
+         "version": "2.88.2",
+         "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
+         "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
+         "deprecated": "request has been deprecated, see https://github.com/request/request/issues/3142",
+         "license": "Apache-2.0",
+         "dependencies": {
+            "aws-sign2": "~0.7.0",
+            "aws4": "^1.8.0",
+            "caseless": "~0.12.0",
+            "combined-stream": "~1.0.6",
+            "extend": "~3.0.2",
+            "forever-agent": "~0.6.1",
+            "form-data": "~2.3.2",
+            "har-validator": "~5.1.3",
+            "http-signature": "~1.2.0",
+            "is-typedarray": "~1.0.0",
+            "isstream": "~0.1.2",
+            "json-stringify-safe": "~5.0.1",
+            "mime-types": "~2.1.19",
+            "oauth-sign": "~0.9.0",
+            "performance-now": "^2.1.0",
+            "qs": "~6.5.2",
+            "safe-buffer": "^5.1.2",
+            "tough-cookie": "~2.5.0",
+            "tunnel-agent": "^0.6.0",
+            "uuid": "^3.3.2"
+         },
+         "engines": {
+            "node": ">= 6"
+         }
+      },
+      "node_modules/request/node_modules/form-data": {
+         "version": "2.3.3",
+         "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
+         "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+         "license": "MIT",
+         "dependencies": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.6",
+            "mime-types": "^2.1.12"
+         },
+         "engines": {
+            "node": ">= 0.12"
          }
       },
       "node_modules/require-from-string": {
@@ -2713,6 +3052,12 @@
                "url": "https://feross.org/support"
             }
          ],
+         "license": "MIT"
+      },
+      "node_modules/safer-buffer": {
+         "version": "2.1.2",
+         "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+         "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
          "license": "MIT"
       },
       "node_modules/schema-utils": {
@@ -2823,6 +3168,31 @@
          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
          "license": "BSD-3-Clause",
+         "engines": {
+            "node": ">=0.10.0"
+         }
+      },
+      "node_modules/sshpk": {
+         "version": "1.18.0",
+         "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.18.0.tgz",
+         "integrity": "sha512-2p2KJZTSqQ/I3+HX42EpYOa2l3f8Erv8MWKsy2I9uf4wA7yFIkXRffYdsx86y6z4vHtV8u7g+pPlr8/4ouAxsQ==",
+         "license": "MIT",
+         "dependencies": {
+            "asn1": "~0.2.3",
+            "assert-plus": "^1.0.0",
+            "bcrypt-pbkdf": "^1.0.0",
+            "dashdash": "^1.12.0",
+            "ecc-jsbn": "~0.1.1",
+            "getpass": "^0.1.1",
+            "jsbn": "~0.1.0",
+            "safer-buffer": "^2.0.2",
+            "tweetnacl": "~0.14.0"
+         },
+         "bin": {
+            "sshpk-conv": "bin/sshpk-conv",
+            "sshpk-sign": "bin/sshpk-sign",
+            "sshpk-verify": "bin/sshpk-verify"
+         },
          "engines": {
             "node": ">=0.10.0"
          }
@@ -3038,6 +3408,19 @@
             "node": ">=6"
          }
       },
+      "node_modules/tough-cookie": {
+         "version": "2.5.0",
+         "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
+         "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
+         "license": "BSD-3-Clause",
+         "dependencies": {
+            "psl": "^1.1.28",
+            "punycode": "^2.1.1"
+         },
+         "engines": {
+            "node": ">=0.8"
+         }
+      },
       "node_modules/ts-loader": {
          "version": "9.5.2",
          "resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-9.5.2.tgz",
@@ -3075,6 +3458,24 @@
          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
          "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
          "license": "0BSD"
+      },
+      "node_modules/tunnel-agent": {
+         "version": "0.6.0",
+         "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+         "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+         "license": "Apache-2.0",
+         "dependencies": {
+            "safe-buffer": "^5.0.1"
+         },
+         "engines": {
+            "node": "*"
+         }
+      },
+      "node_modules/tweetnacl": {
+         "version": "0.14.5",
+         "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+         "integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==",
+         "license": "Unlicense"
       },
       "node_modules/typescript": {
          "version": "5.8.3",
@@ -3132,6 +3533,30 @@
          "license": "BSD-2-Clause",
          "dependencies": {
             "punycode": "^2.1.0"
+         }
+      },
+      "node_modules/uuid": {
+         "version": "3.4.0",
+         "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+         "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+         "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
+         "license": "MIT",
+         "bin": {
+            "uuid": "bin/uuid"
+         }
+      },
+      "node_modules/verror": {
+         "version": "1.10.0",
+         "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+         "integrity": "sha512-ZZKSmDAEFOijERBLkmYfJ+vmk3w+7hOLYDNkRCuRuMJGEmqYNCNLyBBFwWKVMhfwaEF3WOd0Zlw86U/WC/+nYw==",
+         "engines": [
+            "node >=0.6.0"
+         ],
+         "license": "MIT",
+         "dependencies": {
+            "assert-plus": "^1.0.0",
+            "core-util-is": "1.0.2",
+            "extsprintf": "^1.2.0"
          }
       },
       "node_modules/watchpack": {
@@ -3636,6 +4061,11 @@
             "@babel/plugin-transform-modules-commonjs": "^7.27.1",
             "@babel/plugin-transform-typescript": "^7.27.1"
          }
+      },
+      "@babel/runtime": {
+         "version": "7.28.4",
+         "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.4.tgz",
+         "integrity": "sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ=="
       },
       "@babel/template": {
          "version": "7.27.2",
@@ -4177,10 +4607,33 @@
             "color-convert": "^2.0.1"
          }
       },
+      "asn1": {
+         "version": "0.2.6",
+         "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
+         "integrity": "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==",
+         "requires": {
+            "safer-buffer": "~2.1.0"
+         }
+      },
+      "assert-plus": {
+         "version": "1.0.0",
+         "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+         "integrity": "sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw=="
+      },
       "asynckit": {
          "version": "0.4.0",
          "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
          "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+      },
+      "aws-sign2": {
+         "version": "0.7.0",
+         "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+         "integrity": "sha512-08kcGqnYf/YmjoRhfxyu+CLxBjUtHLXLXX/vUfx9l2LYzG3c1m61nrpyFUZI6zeS+Li/wWMMidD9KgrqtGq3mA=="
+      },
+      "aws4": {
+         "version": "1.13.2",
+         "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.13.2.tgz",
+         "integrity": "sha512-lHe62zvbTB5eEABUVi/AwVh0ZKY9rMMDhmm+eeyuuUQbQ3+J+fONVQOZyj+DdrvD4BY33uYniyRJ4UJIaSKAfw=="
       },
       "axios": {
          "version": "1.10.0",
@@ -4190,6 +4643,15 @@
             "follow-redirects": "^1.15.6",
             "form-data": "^4.0.0",
             "proxy-from-env": "^1.1.0"
+         }
+      },
+      "axios-retry": {
+         "version": "3.9.1",
+         "resolved": "https://registry.npmjs.org/axios-retry/-/axios-retry-3.9.1.tgz",
+         "integrity": "sha512-8PJDLJv7qTTMMwdnbMvrLYuvB47M81wRtxQmEdV5w4rgbTXTt+vtPkXwajOfOdSyv/wZICJOC+/UhXH4aQ/R+w==",
+         "requires": {
+            "@babel/runtime": "^7.15.4",
+            "is-retry-allowed": "^2.2.0"
          }
       },
       "babel-loader": {
@@ -4214,6 +4676,14 @@
          "version": "1.0.2",
          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
          "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+      },
+      "bcrypt-pbkdf": {
+         "version": "1.0.2",
+         "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+         "integrity": "sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==",
+         "requires": {
+            "tweetnacl": "^0.14.3"
+         }
       },
       "big.js": {
          "version": "5.2.2",
@@ -4276,6 +4746,11 @@
          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001703.tgz",
          "integrity": "sha512-kRlAGTRWgPsOj7oARC9m1okJEXdL/8fekFVcxA8Hl7GH4r/sN4OJn/i6Flde373T50KS7Y37oFbMwlE8+F42kQ=="
       },
+      "caseless": {
+         "version": "0.12.0",
+         "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+         "integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw=="
+      },
       "chalk": {
          "version": "4.1.2",
          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -4327,6 +4802,11 @@
          "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
          "peer": true
       },
+      "core-util-is": {
+         "version": "1.0.2",
+         "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+         "integrity": "sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ=="
+      },
       "cross-spawn": {
          "version": "7.0.6",
          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -4335,6 +4815,14 @@
             "path-key": "^3.1.0",
             "shebang-command": "^2.0.0",
             "which": "^2.0.1"
+         }
+      },
+      "dashdash": {
+         "version": "1.14.1",
+         "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+         "integrity": "sha512-jRFi8UDGo6j+odZiEpjazZaWqEal3w/basFjQHQEwVtZJGDpxbH1MeYluwCS8Xq5wmLJooDlMgvVarmWfGM44g==",
+         "requires": {
+            "assert-plus": "^1.0.0"
          }
       },
       "debounce": {
@@ -4379,6 +4867,15 @@
          "version": "0.2.0",
          "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
          "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA=="
+      },
+      "ecc-jsbn": {
+         "version": "0.1.2",
+         "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+         "integrity": "sha512-eh9O+hwRHNbG4BLTjEl3nw044CkGm5X6LoaCf7LPp7UU8Qrt47JYNi6nPX8xjW97TKGKm1ouctg0QSpZe9qrnw==",
+         "requires": {
+            "jsbn": "~0.1.0",
+            "safer-buffer": "^2.1.0"
+         }
       },
       "electron-to-chromium": {
          "version": "1.5.115",
@@ -4487,6 +4984,16 @@
          "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
          "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q=="
       },
+      "extend": {
+         "version": "3.0.2",
+         "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+         "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+      },
+      "extsprintf": {
+         "version": "1.3.0",
+         "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+         "integrity": "sha512-11Ndz7Nv+mvAC1j0ktTa7fAb0vLyGGX+rMHNBYQviQDGU0Hw7lhctJANqbPhu9nV9/izT/IntTgZ7Im/9LJs9g=="
+      },
       "fast-deep-equal": {
          "version": "3.1.3",
          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -4538,6 +5045,11 @@
             "cross-spawn": "^7.0.6",
             "signal-exit": "^4.0.1"
          }
+      },
+      "forever-agent": {
+         "version": "0.6.1",
+         "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+         "integrity": "sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw=="
       },
       "form-data": {
          "version": "4.0.3",
@@ -4594,6 +5106,14 @@
             "es-object-atoms": "^1.0.0"
          }
       },
+      "getpass": {
+         "version": "0.1.7",
+         "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+         "integrity": "sha512-0fzj9JxOLfJ+XGLhR8ze3unN0KZCgZwiSSDz168VERjK8Wl8kVSdcu2kspd4s4wtAa1y/qrVRiAA0WclVsu0ng==",
+         "requires": {
+            "assert-plus": "^1.0.0"
+         }
+      },
       "glob": {
          "version": "11.0.1",
          "resolved": "https://registry.npmjs.org/glob/-/glob-11.0.1.tgz",
@@ -4630,6 +5150,38 @@
             "duplexer": "^0.1.2"
          }
       },
+      "har-schema": {
+         "version": "2.0.0",
+         "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+         "integrity": "sha512-Oqluz6zhGX8cyRaTQlFMPw80bSJVG2x/cFb8ZPhUILGgHka9SsokCCOQgpveePerqidZOrT14ipqfJb7ILcW5Q=="
+      },
+      "har-validator": {
+         "version": "5.1.5",
+         "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
+         "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
+         "requires": {
+            "ajv": "^6.12.3",
+            "har-schema": "^2.0.0"
+         },
+         "dependencies": {
+            "ajv": {
+               "version": "6.12.6",
+               "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+               "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+               "requires": {
+                  "fast-deep-equal": "^3.1.1",
+                  "fast-json-stable-stringify": "^2.0.0",
+                  "json-schema-traverse": "^0.4.1",
+                  "uri-js": "^4.2.2"
+               }
+            },
+            "json-schema-traverse": {
+               "version": "0.4.1",
+               "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+               "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+            }
+         }
+      },
       "has-flag": {
          "version": "4.0.0",
          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -4660,6 +5212,16 @@
          "version": "2.0.2",
          "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
          "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg=="
+      },
+      "http-signature": {
+         "version": "1.2.0",
+         "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+         "integrity": "sha512-CAbnr6Rz4CYQkLYUtSNXxQPUH2gK8f3iWexVlsnMeD+GjlsQ0Xsy1cOX+mN3dtxYomRy21CiOzU8Uhw6OwncEQ==",
+         "requires": {
+            "assert-plus": "^1.0.0",
+            "jsprim": "^1.2.2",
+            "sshpk": "^1.7.0"
+         }
       },
       "is-core-module": {
          "version": "2.16.1",
@@ -4692,10 +5254,25 @@
             "@types/estree": "*"
          }
       },
+      "is-retry-allowed": {
+         "version": "2.2.0",
+         "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-2.2.0.tgz",
+         "integrity": "sha512-XVm7LOeLpTW4jV19QSH38vkswxoLud8sQ57YwJVTPWdiaI9I8keEhGFpBlslyVsgdQy4Opg8QOLb8YRgsyZiQg=="
+      },
+      "is-typedarray": {
+         "version": "1.0.0",
+         "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+         "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA=="
+      },
       "isexe": {
          "version": "2.0.0",
          "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
          "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
+      },
+      "isstream": {
+         "version": "0.1.2",
+         "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+         "integrity": "sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g=="
       },
       "jackspeak": {
          "version": "4.1.0",
@@ -4725,10 +5302,23 @@
             }
          }
       },
+      "jpeg-extract": {
+         "version": "3.0.1",
+         "resolved": "https://registry.npmjs.org/jpeg-extract/-/jpeg-extract-3.0.1.tgz",
+         "integrity": "sha512-tCBe2CjnmsUPLVjXWj5r0Q7KDepWHlgL42U2N0/dokjkiyQOGb3HwI7vYL1t53Vnj80YOYNuz8oKSbUrHqgrFw==",
+         "requires": {
+            "request": "^2.88.0"
+         }
+      },
       "js-tokens": {
          "version": "4.0.0",
          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
          "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+      },
+      "jsbn": {
+         "version": "0.1.1",
+         "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+         "integrity": "sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg=="
       },
       "jsesc": {
          "version": "3.1.0",
@@ -4740,15 +5330,36 @@
          "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
          "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w=="
       },
+      "json-schema": {
+         "version": "0.4.0",
+         "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+         "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA=="
+      },
       "json-schema-traverse": {
          "version": "1.0.0",
          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
          "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
       },
+      "json-stringify-safe": {
+         "version": "5.0.1",
+         "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+         "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA=="
+      },
       "json5": {
          "version": "2.2.3",
          "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
          "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="
+      },
+      "jsprim": {
+         "version": "1.4.2",
+         "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.2.tgz",
+         "integrity": "sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==",
+         "requires": {
+            "assert-plus": "1.0.0",
+            "extsprintf": "1.3.0",
+            "json-schema": "0.4.0",
+            "verror": "1.10.0"
+         }
       },
       "loader-runner": {
          "version": "4.3.0",
@@ -4865,6 +5476,11 @@
          "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.19.tgz",
          "integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw=="
       },
+      "oauth-sign": {
+         "version": "0.9.0",
+         "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
+         "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
+      },
       "openai": {
          "version": "5.8.2",
          "resolved": "https://registry.npmjs.org/openai/-/openai-5.8.2.tgz",
@@ -4928,6 +5544,11 @@
             }
          }
       },
+      "performance-now": {
+         "version": "2.1.0",
+         "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+         "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow=="
+      },
       "picocolors": {
          "version": "1.1.1",
          "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -4943,10 +5564,23 @@
          "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
          "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
       },
+      "psl": {
+         "version": "1.15.0",
+         "resolved": "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz",
+         "integrity": "sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==",
+         "requires": {
+            "punycode": "^2.3.1"
+         }
+      },
       "punycode": {
          "version": "2.3.1",
          "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
          "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="
+      },
+      "qs": {
+         "version": "6.5.3",
+         "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.3.tgz",
+         "integrity": "sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA=="
       },
       "randombytes": {
          "version": "2.1.0",
@@ -4995,6 +5629,45 @@
                   "@types/json-schema": "^7.0.8",
                   "ajv": "^6.12.5",
                   "ajv-keywords": "^3.5.2"
+               }
+            }
+         }
+      },
+      "request": {
+         "version": "2.88.2",
+         "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
+         "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
+         "requires": {
+            "aws-sign2": "~0.7.0",
+            "aws4": "^1.8.0",
+            "caseless": "~0.12.0",
+            "combined-stream": "~1.0.6",
+            "extend": "~3.0.2",
+            "forever-agent": "~0.6.1",
+            "form-data": "~2.3.2",
+            "har-validator": "~5.1.3",
+            "http-signature": "~1.2.0",
+            "is-typedarray": "~1.0.0",
+            "isstream": "~0.1.2",
+            "json-stringify-safe": "~5.0.1",
+            "mime-types": "~2.1.19",
+            "oauth-sign": "~0.9.0",
+            "performance-now": "^2.1.0",
+            "qs": "~6.5.2",
+            "safe-buffer": "^5.1.2",
+            "tough-cookie": "~2.5.0",
+            "tunnel-agent": "^0.6.0",
+            "uuid": "^3.3.2"
+         },
+         "dependencies": {
+            "form-data": {
+               "version": "2.3.3",
+               "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
+               "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+               "requires": {
+                  "asynckit": "^0.4.0",
+                  "combined-stream": "^1.0.6",
+                  "mime-types": "^2.1.12"
                }
             }
          }
@@ -5056,6 +5729,11 @@
          "version": "5.2.1",
          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+      },
+      "safer-buffer": {
+         "version": "2.1.2",
+         "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+         "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
       },
       "schema-utils": {
          "version": "4.3.2",
@@ -5128,6 +5806,22 @@
                "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
                "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
             }
+         }
+      },
+      "sshpk": {
+         "version": "1.18.0",
+         "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.18.0.tgz",
+         "integrity": "sha512-2p2KJZTSqQ/I3+HX42EpYOa2l3f8Erv8MWKsy2I9uf4wA7yFIkXRffYdsx86y6z4vHtV8u7g+pPlr8/4ouAxsQ==",
+         "requires": {
+            "asn1": "~0.2.3",
+            "assert-plus": "^1.0.0",
+            "bcrypt-pbkdf": "^1.0.0",
+            "dashdash": "^1.12.0",
+            "ecc-jsbn": "~0.1.1",
+            "getpass": "^0.1.1",
+            "jsbn": "~0.1.0",
+            "safer-buffer": "^2.0.2",
+            "tweetnacl": "~0.14.0"
          }
       },
       "string-width": {
@@ -5252,6 +5946,15 @@
          "resolved": "https://registry.npmjs.org/totalist/-/totalist-3.0.1.tgz",
          "integrity": "sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ=="
       },
+      "tough-cookie": {
+         "version": "2.5.0",
+         "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
+         "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
+         "requires": {
+            "psl": "^1.1.28",
+            "punycode": "^2.1.1"
+         }
+      },
       "ts-loader": {
          "version": "9.5.2",
          "resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-9.5.2.tgz",
@@ -5275,6 +5978,19 @@
          "version": "2.8.1",
          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
          "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
+      },
+      "tunnel-agent": {
+         "version": "0.6.0",
+         "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+         "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+         "requires": {
+            "safe-buffer": "^5.0.1"
+         }
+      },
+      "tweetnacl": {
+         "version": "0.14.5",
+         "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+         "integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA=="
       },
       "typescript": {
          "version": "5.8.3",
@@ -5301,6 +6017,21 @@
          "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
          "requires": {
             "punycode": "^2.1.0"
+         }
+      },
+      "uuid": {
+         "version": "3.4.0",
+         "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+         "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+      },
+      "verror": {
+         "version": "1.10.0",
+         "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+         "integrity": "sha512-ZZKSmDAEFOijERBLkmYfJ+vmk3w+7hOLYDNkRCuRuMJGEmqYNCNLyBBFwWKVMhfwaEF3WOd0Zlw86U/WC/+nYw==",
+         "requires": {
+            "assert-plus": "^1.0.0",
+            "core-util-is": "1.0.2",
+            "extsprintf": "^1.2.0"
          }
       },
       "watchpack": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-   "name": "@scrypted/vscode-typescript",
+   "name": "@scrypted/simplisafe",
    "scripts": {
       "scrypted-setup-project": "scrypted-setup-project",
       "prescrypted-setup-project": "scrypted-package-json",
@@ -15,14 +15,18 @@
    },
    "scrypted": {
       "rollup": true,
-      "name": "TypeScript Light",
-      "type": "Light",
+      "name": "SimpliSafe Cameras",
+      "type": "DeviceProvider",
       "interfaces": [
-         "OnOff"
+         "DeviceProvider",
+         "Settings"
       ]
    },
    "dependencies": {
-      "@scrypted/sdk": "^0.5.29"
+      "@scrypted/sdk": "^0.5.29",
+      "axios": "^1.7.7",
+      "axios-retry": "^3.9.1",
+      "jpeg-extract": "^3.0.1"
    },
    "devDependencies": {
       "@types/node": "^24.0.10"

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,32 +1,921 @@
-// https://developer.scrypted.app/#getting-started
-// package.json contains the metadata (name, interfaces) about this device
-// under the "scrypted" key.
-import { OnOff, ScryptedDeviceBase } from '@scrypted/sdk';
+import sdk, {
+    Camera,
+    Device,
+    DeviceProvider,
+    FFmpegInput,
+    MediaObject,
+    RequestMediaStreamOptions,
+    RequestPictureOptions,
+    ResponseMediaStreamOptions,
+    ResponsePictureOptions,
+    ScryptedDeviceBase,
+    ScryptedDeviceType,
+    ScryptedInterface,
+    Setting,
+    SettingValue,
+    Settings,
+    VideoCamera,
+} from '@scrypted/sdk';
+import axios, { AxiosError, AxiosInstance, AxiosRequestConfig } from 'axios';
+import axiosRetry from 'axios-retry';
+import { EventEmitter } from 'events';
+import crypto from 'crypto';
+import { lookup } from 'dns/promises';
+import jpegExtract from 'jpeg-extract';
 
-console.log('Hello World. This will create a virtual OnOff device.');
-// OnOff is a simple binary switch. See "interfaces"  in package.json
-// to add support for more capabilities, like Brightness or Lock.
+const { deviceManager, mediaManager } = sdk;
 
-class TypescriptLight extends ScryptedDeviceBase implements OnOff {
-    constructor(nativeId?: string) {
-        super(nativeId);
-        this.on = this.on || false;
-    }
-    async turnOff() {
-        this.console.log('turnOff was called!');
-        this.on = false;
-    }
-    async turnOn() {
-        // set a breakpoint here.
-        this.console.log('turnOn was called!');
+const SS_OAUTH_AUTH_URL = 'https://auth.simplisafe.com/authorize';
+const SS_OAUTH_CLIENT_ID = '42aBZ5lYrVW12jfOuu3CQROitwxg9sN5';
+const SS_OAUTH_AUTH0_CLIENT = 'eyJ2ZXJzaW9uIjoiMi4zLjIiLCJuYW1lIjoiQXV0aDAuc3dpZnQiLCJlbnYiOnsic3dpZnQiOiI1LngiLCJpT1MiOiIxNi4zIn19';
+const SS_OAUTH_REDIRECT_URI = 'com.simplisafe.mobile://auth.simplisafe.com/ios/com.simplisafe.mobile/callback';
+const SS_OAUTH_SCOPE = 'offline_access%20email%20openid%20https://api.simplisafe.com/scopes/user:platform';
+const SS_OAUTH_AUDIENCE = 'https://api.simplisafe.com/';
+const SS_OAUTH_DEVICE = 'iPhone';
+const SS_OAUTH_DEVICE_UUID = '0000007E-0000-1000-8000-0026BB765291';
 
-        this.console.log("Let's pretend to perform a web request on an API that would turn on a light.");
-        const response = await fetch('http://jsonip.com');
-        const json = await response.json();
-        this.console.log(`my ip: ${json.ip}`);
+const subscriptionCacheTime = 3000;
+const cameraCacheTime = 15000;
+const rateLimitInitialInterval = 60_000;
+const rateLimitMaxInterval = 2 * 60 * 60 * 1000;
+const mediaHostTtl = 5 * 60 * 1000;
 
-        this.on = true;
+const ssOAuth: AxiosInstance = axios.create({
+    baseURL: 'https://auth.simplisafe.com/oauth',
+});
+axiosRetry(ssOAuth, { retries: 3 });
+
+export const AUTH_EVENTS = {
+    REFRESH_CREDENTIALS_SUCCESS: 'REFRESH_CREDENTIALS_SUCCESS',
+    REFRESH_CREDENTIALS_FAILURE: 'REFRESH_CREDENTIALS_FAILURE',
+} as const;
+
+class RateLimitError extends Error {
+    constructor(message: string) {
+        super(message);
+        this.name = 'RateLimitError';
     }
 }
 
-export default TypescriptLight;
+interface SimplisafeCameraAdminSettings {
+    fps?: number;
+    bitRate?: number;
+    firmwareVersion?: string;
+}
+
+interface SimplisafeCameraSettings {
+    cameraName?: string;
+    pictureQuality?: string;
+    admin?: SimplisafeCameraAdminSettings;
+}
+
+interface SimplisafeCameraProviders {
+    recording?: string;
+}
+
+interface SimplisafeCameraSupportedFeatures {
+    privacyShutter?: boolean;
+    providers?: SimplisafeCameraProviders;
+}
+
+interface SimplisafeCameraDetails {
+    uuid: string;
+    name?: string;
+    model?: string;
+    status?: string;
+    cameraSettings?: SimplisafeCameraSettings;
+    supportedFeatures?: SimplisafeCameraSupportedFeatures;
+    [key: string]: unknown;
+}
+
+type DebugProvider = () => boolean;
+
+class SimplisafeAuthManager extends EventEmitter {
+    accessToken?: string;
+    refreshToken?: string;
+    tokenType = 'Bearer';
+    expiry = 0;
+    private readonly storage: Storage;
+    private readonly log: Console;
+    private debug: boolean;
+    private codeVerifier: string;
+    private readonly codeChallenge: string;
+
+    constructor(storage: Storage, log: Console, debug: boolean) {
+        super();
+        this.storage = storage;
+        this.log = log;
+        this.debug = debug;
+
+        this.accessToken = storage.getItem('accessToken') || undefined;
+        this.refreshToken = storage.getItem('refreshToken') || undefined;
+        this.tokenType = storage.getItem('tokenType') || 'Bearer';
+        const storedExpiry = storage.getItem('expiry');
+        if (storedExpiry) {
+            this.expiry = parseInt(storedExpiry, 10);
+        }
+
+        const storedVerifier = storage.getItem('codeVerifier');
+        this.codeVerifier = storedVerifier || this.base64URLEncode(crypto.randomBytes(32));
+        storage.setItem('codeVerifier', this.codeVerifier);
+        this.codeChallenge = this.base64URLEncode(this.sha256(Buffer.from(this.codeVerifier)));
+    }
+
+    setDebug(debug: boolean): void {
+        this.debug = debug;
+    }
+
+    hasRefreshToken(): boolean {
+        return !!this.refreshToken;
+    }
+
+    isAuthenticated(): boolean {
+        return !!this.accessToken && Date.now() < this.expiry;
+    }
+
+    getSSAuthURL(): string {
+        const loginURL = new URL(SS_OAUTH_AUTH_URL);
+        loginURL.searchParams.append('client_id', SS_OAUTH_CLIENT_ID);
+        loginURL.searchParams.append('scope', 'SCOPE');
+        loginURL.searchParams.append('response_type', 'code');
+        loginURL.searchParams.append('redirect_uri', SS_OAUTH_REDIRECT_URI);
+        loginURL.searchParams.append('code_challenge_method', 'S256');
+        loginURL.searchParams.append('code_challenge', this.codeChallenge);
+        loginURL.searchParams.append('audience', 'AUDIENCE');
+        loginURL.searchParams.append('auth0Client', SS_OAUTH_AUTH0_CLIENT);
+        loginURL.searchParams.append('device', SS_OAUTH_DEVICE);
+        loginURL.searchParams.append('device_id', SS_OAUTH_DEVICE_UUID);
+        return loginURL.toString().replace('SCOPE', SS_OAUTH_SCOPE).replace('AUDIENCE', SS_OAUTH_AUDIENCE);
+    }
+
+    parseCodeFromURL(redirectURLStr: string): string {
+        let code: string | null = null;
+        try {
+            const redirectURL = new URL(redirectURLStr);
+            code = redirectURL.searchParams.get('code');
+        } catch (error) {
+            throw new Error('Invalid redirect URL');
+        }
+
+        if (!code) {
+            throw new Error('Authorization code was not present in redirect URL');
+        }
+
+        return code;
+    }
+
+    async getToken(authorization: string): Promise<string> {
+        const code = authorization.includes('://') ? this.parseCodeFromURL(authorization) : authorization;
+        try {
+            const tokenResponse = await ssOAuth.post('/token', {
+                grant_type: 'authorization_code',
+                client_id: SS_OAUTH_CLIENT_ID,
+                code_verifier: this.codeVerifier,
+                code,
+                redirect_uri: SS_OAUTH_REDIRECT_URI,
+            });
+
+            await this.storeToken(tokenResponse.data);
+            if (this.debug) this.log.log('Retrieved SimpliSafe access token.');
+            return this.accessToken!;
+        } catch (err: any) {
+            throw new Error(`Error getting token: ${err?.message ?? err}`);
+        }
+    }
+
+    async refreshCredentials(): Promise<void> {
+        if (!this.refreshToken) {
+            throw new Error('No refresh token configured. Complete authentication in the plugin settings.');
+        }
+
+        try {
+            const refreshTokenResponse = await ssOAuth.post('/token', {
+                grant_type: 'refresh_token',
+                client_id: SS_OAUTH_CLIENT_ID,
+                refresh_token: this.refreshToken,
+            }, {
+                headers: {
+                    Host: 'auth.simplisafe.com',
+                    'Content-Type': 'application/json',
+                    'Auth0-Client': SS_OAUTH_AUTH0_CLIENT,
+                },
+            });
+            await this.storeToken(refreshTokenResponse.data);
+            this.emit(AUTH_EVENTS.REFRESH_CREDENTIALS_SUCCESS);
+            if (this.debug) this.log.log('SimpliSafe credentials refreshed successfully.');
+        } catch (err: any) {
+            if (this.debug) this.log.error('SimpliSafe credentials refresh failed.', err?.message ?? err);
+            this.emit(AUTH_EVENTS.REFRESH_CREDENTIALS_FAILURE);
+            throw err;
+        }
+    }
+
+    setRefreshToken(token?: string): void {
+        this.refreshToken = token || undefined;
+        if (this.refreshToken) {
+            this.storage.setItem('refreshToken', this.refreshToken);
+        } else {
+            this.storage.removeItem('refreshToken');
+        }
+        this.expiry = 0;
+    }
+
+    clearTokens(): void {
+        this.accessToken = undefined;
+        this.refreshToken = undefined;
+        this.expiry = 0;
+        this.storage.removeItem('accessToken');
+        this.storage.removeItem('refreshToken');
+        this.storage.removeItem('expiry');
+    }
+
+    private base64URLEncode(buffer: Buffer): string {
+        return buffer.toString('base64')
+            .replace(/\+/g, '-')
+            .replace(/\//g, '_')
+            .replace(/=/g, '');
+    }
+
+    private sha256(buffer: Buffer): Buffer {
+        return crypto.createHash('sha256').update(buffer).digest();
+    }
+
+    private async storeToken(token: any): Promise<void> {
+        this.accessToken = token.access_token;
+        this.refreshToken = token.refresh_token ?? this.refreshToken;
+        const expiresIn = parseInt(token.expires_in ?? '0', 10);
+        const safetyWindow = 60 * 1000;
+        this.expiry = Date.now() + Math.max(0, expiresIn * 1000 - safetyWindow);
+        this.tokenType = token.token_type ?? 'Bearer';
+
+        if (this.accessToken) {
+            this.storage.setItem('accessToken', this.accessToken);
+        } else {
+            this.storage.removeItem('accessToken');
+        }
+
+        if (this.refreshToken) {
+            this.storage.setItem('refreshToken', this.refreshToken);
+        } else {
+            this.storage.removeItem('refreshToken');
+        }
+
+        this.storage.setItem('tokenType', this.tokenType);
+        this.storage.setItem('expiry', this.expiry.toString());
+    }
+}
+
+class SimplisafeApi {
+    private readonly authManager: SimplisafeAuthManager;
+    private readonly log: Console;
+    private readonly axios: AxiosInstance;
+    private debug: boolean;
+    private accountNumber?: string;
+    private userId?: string;
+    private subId?: string;
+    private lastSubscription?: { id: string; data: any; timestamp: number };
+    private cameraCache?: { data: SimplisafeCameraDetails[]; timestamp: number };
+    private isBlocked = false;
+    private nextAttempt = 0;
+    private nextBlockInterval = rateLimitInitialInterval;
+
+    constructor(authManager: SimplisafeAuthManager, log: Console, debug: boolean) {
+        this.authManager = authManager;
+        this.log = log;
+        this.debug = debug;
+        this.axios = axios.create({
+            baseURL: 'https://api.simplisafe.com/v1',
+        });
+        axiosRetry(this.axios, { retries: 2 });
+    }
+
+    setDebug(debug: boolean): void {
+        this.debug = debug;
+    }
+
+    setAccountNumber(accountNumber?: string): void {
+        this.accountNumber = accountNumber || undefined;
+        this.subId = undefined;
+        this.clearCache();
+    }
+
+    clearCache(): void {
+        this.userId = undefined;
+        this.lastSubscription = undefined;
+        this.cameraCache = undefined;
+    }
+
+    async getAccessToken(): Promise<string> {
+        if (!this.authManager.accessToken || !this.authManager.isAuthenticated()) {
+            await this.authManager.refreshCredentials();
+        }
+
+        if (!this.authManager.accessToken) {
+            throw new Error('Unable to retrieve SimpliSafe access token.');
+        }
+
+        return this.authManager.accessToken;
+    }
+
+    async getCameras(forceRefresh = false): Promise<SimplisafeCameraDetails[]> {
+        if (!forceRefresh && this.cameraCache && Date.now() - this.cameraCache.timestamp < cameraCacheTime) {
+            return this.cameraCache.data;
+        }
+
+        const system = await this.getAlarmSystem(forceRefresh);
+        const cameras: SimplisafeCameraDetails[] = system?.cameras ?? [];
+        this.cameraCache = {
+            data: cameras,
+            timestamp: Date.now(),
+        };
+        return cameras;
+    }
+
+    private async request<T>(config: AxiosRequestConfig): Promise<T> {
+        if (this.isBlocked && Date.now() < this.nextAttempt) {
+            throw new RateLimitError('Blocking request: rate limited');
+        }
+
+        const accessToken = await this.getAccessToken();
+
+        try {
+            const response = await this.axios.request<T>({
+                ...config,
+                headers: {
+                    ...config.headers,
+                    Authorization: `${this.authManager.tokenType} ${accessToken}`,
+                },
+            });
+            this.resetRateLimit();
+            return response.data;
+        } catch (error) {
+            const axiosError = error as AxiosError;
+            if (!axiosError.response) {
+                this.setRateLimit();
+                throw new RateLimitError('SimpliSafe request failed: no response received.');
+            }
+
+            if (axiosError.response.status === 403) {
+                this.setRateLimit();
+                throw new RateLimitError('SimpliSafe rejected the request (rate limited or auth failure).');
+            }
+
+            throw axiosError.response.data ?? axiosError;
+        }
+    }
+
+    private resetRateLimit(): void {
+        this.isBlocked = false;
+        this.nextBlockInterval = rateLimitInitialInterval;
+    }
+
+    private setRateLimit(): void {
+        this.isBlocked = true;
+        this.nextAttempt = Date.now() + this.nextBlockInterval;
+        if (this.nextBlockInterval < rateLimitMaxInterval) {
+            this.nextBlockInterval *= 2;
+        }
+    }
+
+    private async getUserId(): Promise<string> {
+        if (this.userId) {
+            return this.userId;
+        }
+
+        const data = await this.request<{ userId: string }>({
+            method: 'GET',
+            url: '/api/authCheck',
+        });
+        this.userId = data.userId;
+        return this.userId;
+    }
+
+    private async getSubscriptions(): Promise<any[]> {
+        const userId = await this.getUserId();
+        const data = await this.request<{ subscriptions: any[] }>({
+            method: 'GET',
+            url: `/users/${userId}/subscriptions?activeOnly=false`,
+        });
+
+        let subscriptions = data.subscriptions.filter(s => [7, 10, 20].includes(s.sStatus));
+        if (this.accountNumber) {
+            subscriptions = subscriptions.filter(s => s.location?.account === this.accountNumber);
+        }
+
+        if (subscriptions.length > 1) {
+            subscriptions = subscriptions.filter(s => s.activated > 0);
+        }
+
+        if (subscriptions.length === 1) {
+            this.subId = subscriptions[0].sid;
+        }
+
+        return subscriptions;
+    }
+
+    private async getSubscription(forceRefresh = false): Promise<any> {
+        let subscriptionId = this.subId;
+
+        if (!subscriptionId) {
+            const subscriptions = await this.getSubscriptions();
+            if (subscriptions.length === 1) {
+                subscriptionId = subscriptions[0].sid;
+                this.subId = subscriptionId;
+            } else if (subscriptions.length === 0) {
+                throw new Error('No active SimpliSafe monitoring plan found for this account.');
+            } else {
+                const accounts = subscriptions.map(s => s.location?.account).filter(Boolean);
+                throw new Error(`Multiple SimpliSafe accounts found. Specify an account number in the plugin settings. Accounts: ${accounts.join(', ')}`);
+            }
+        }
+
+        if (!subscriptionId) {
+            throw new Error('Unable to determine SimpliSafe subscription identifier.');
+        }
+
+        const shouldFetch = forceRefresh
+            || !this.lastSubscription
+            || this.lastSubscription.id !== subscriptionId
+            || Date.now() - this.lastSubscription.timestamp > subscriptionCacheTime;
+
+        if (shouldFetch) {
+            const subscription = await this.request<any>({
+                method: 'GET',
+                url: `/subscriptions/${subscriptionId}/`,
+            });
+            this.lastSubscription = {
+                id: subscriptionId,
+                data: subscription,
+                timestamp: Date.now(),
+            };
+        }
+
+        return this.lastSubscription!.data;
+    }
+
+    private async getAlarmSystem(forceRefresh = false): Promise<any> {
+        const subscription = await this.getSubscription(forceRefresh);
+        const system = subscription?.location?.system;
+        if (!system) {
+            throw new Error('SimpliSafe subscription data did not include system details.');
+        }
+        return system;
+    }
+}
+
+class SimplisafeCamera extends ScryptedDeviceBase implements Camera, VideoCamera {
+    private readonly api: SimplisafeApi;
+    private readonly authManager: SimplisafeAuthManager;
+    private readonly getDebug: DebugProvider;
+    private details?: SimplisafeCameraDetails;
+    private streamOptions?: ResponseMediaStreamOptions[];
+    private pictureOptions?: ResponsePictureOptions[];
+    private mediaHost?: string;
+    private mediaHostTimestamp = 0;
+
+    constructor(nativeId: string, api: SimplisafeApi, authManager: SimplisafeAuthManager, getDebug: DebugProvider) {
+        super(nativeId);
+        this.api = api;
+        this.authManager = authManager;
+        this.getDebug = getDebug;
+    }
+
+    updateDetails(details: SimplisafeCameraDetails): void {
+        this.details = details;
+        this.streamOptions = undefined;
+        this.pictureOptions = undefined;
+        const name = this.getCameraName(details);
+        this.name = name;
+        this.info = {
+            manufacturer: 'SimpliSafe',
+            model: details.model,
+            serialNumber: details.uuid,
+            firmware: details.cameraSettings?.admin?.firmwareVersion,
+        };
+        this.online = details.status === 'online';
+    }
+
+    async getVideoStreamOptions(): Promise<ResponseMediaStreamOptions[]> {
+        if (!this.details) {
+            throw new Error('Camera details are unavailable.');
+        }
+
+        if (!this.streamOptions) {
+            this.streamOptions = this.buildStreamOptions(this.details);
+        }
+
+        return this.streamOptions;
+    }
+
+    async getVideoStream(options?: RequestMediaStreamOptions): Promise<MediaObject> {
+        if (!this.details) {
+            throw new Error('Camera details are unavailable.');
+        }
+
+        if (this.isUnsupported(this.details)) {
+            throw new Error(`${this.name} does not support SimpliSafe cloud streaming.`);
+        }
+
+        const streamOptions = await this.getVideoStreamOptions();
+        let selected: ResponseMediaStreamOptions | undefined;
+        if (options?.id) {
+            selected = streamOptions.find(o => o.id === options.id);
+        }
+        selected = selected ?? streamOptions[streamOptions.length - 1];
+
+        const width = selected.video?.width ?? 1920;
+        const accessToken = await this.api.getAccessToken();
+        const host = await this.getMediaHost();
+        const url = `https://${host}/v1/${this.details.uuid}/flv?x=${width}&audioEncoding=AAC`;
+        const inputArguments = [
+            '-re',
+            '-headers',
+            `Authorization: Bearer ${accessToken}`,
+            '-i',
+            url,
+        ];
+
+        const ffmpegInput: FFmpegInput = {
+            inputArguments,
+            mediaStreamOptions: selected,
+            container: 'flv',
+        };
+
+        if (this.getDebug()) {
+            this.console.log(`${this.name} streaming via ${url}`);
+        }
+
+        return mediaManager.createFFmpegMediaObject(ffmpegInput);
+    }
+
+    async takePicture(options?: RequestPictureOptions): Promise<MediaObject> {
+        if (!this.details) {
+            throw new Error('Camera details are unavailable.');
+        }
+
+        if (this.isUnsupported(this.details)) {
+            throw new Error(`${this.name} does not support snapshots.`);
+        }
+
+        const streamOptions = await this.getVideoStreamOptions();
+        const preferred = streamOptions[streamOptions.length - 1];
+        const width = options?.picture?.width
+            ?? preferred.video?.width
+            ?? 1920;
+
+        const accessToken = await this.api.getAccessToken();
+        const host = await this.getMediaHost();
+        const snapshotUrl = `https://${host}/v1/${this.details.uuid}/mjpg?x=${width}&fr=1`;
+
+        const image = await jpegExtract({
+            url: snapshotUrl,
+            headers: {
+                Authorization: `Bearer ${accessToken}`,
+            },
+            rejectUnauthorized: false,
+        });
+
+        return this.createMediaObject(image, 'image/jpeg');
+    }
+
+    async getPictureOptions(): Promise<ResponsePictureOptions[]> {
+        if (!this.details) {
+            throw new Error('Camera details are unavailable.');
+        }
+
+        if (!this.pictureOptions) {
+            const streamOptions = await this.getVideoStreamOptions();
+            const preferred = streamOptions[streamOptions.length - 1];
+            this.pictureOptions = [
+                {
+                    id: 'default',
+                    name: 'Snapshot',
+                    picture: preferred.video ? {
+                        width: preferred.video.width,
+                        height: preferred.video.height,
+                    } : undefined,
+                    canResize: true,
+                },
+            ];
+        }
+
+        return this.pictureOptions;
+    }
+
+    private buildStreamOptions(details: SimplisafeCameraDetails): ResponseMediaStreamOptions[] {
+        const resolutions: [number, number, number?][] = [
+            [320, 180],
+            [320, 240],
+            [480, 270],
+            [480, 360],
+            [640, 360],
+            [640, 480],
+            [1280, 720],
+            [1920, 1080],
+        ];
+
+        const admin = details.cameraSettings?.admin;
+        const fps = admin?.fps ?? 15;
+        const maxHeight = this.getMaxSupportedHeight(details);
+
+        const filtered = resolutions.filter(([, height]) => height <= maxHeight);
+        return filtered.map(([width, height]) => ({
+            id: `${width}x${height}`,
+            name: `${width}x${height}`,
+            container: 'flv',
+            tool: 'ffmpeg',
+            source: 'cloud',
+            video: {
+                codec: 'h264',
+                width,
+                height,
+                fps,
+                bitrate: admin?.bitRate ? admin.bitRate * 1000 : undefined,
+            },
+            audio: {
+                codec: 'aac',
+                sampleRate: 16000,
+            },
+        }));
+    }
+
+    private getMaxSupportedHeight(details: SimplisafeCameraDetails): number {
+        const quality = details.cameraSettings?.pictureQuality;
+        if (!quality) {
+            return 1080;
+        }
+
+        const match = quality.match(/(\d+)/);
+        if (!match) {
+            return 1080;
+        }
+
+        const height = parseInt(match[1], 10);
+        if (!Number.isFinite(height)) {
+            return 1080;
+        }
+
+        return height;
+    }
+
+    private async getMediaHost(): Promise<string> {
+        const now = Date.now();
+        if (!this.mediaHost || now - this.mediaHostTimestamp > mediaHostTtl) {
+            try {
+                const result = await lookup('media.simplisafe.com');
+                this.mediaHost = result.address;
+                this.mediaHostTimestamp = now;
+            } catch (err) {
+                if (!this.mediaHost) {
+                    throw err;
+                }
+                this.console.warn('Unable to resolve media.simplisafe.com, using cached IP address.', err);
+            }
+        }
+
+        return this.mediaHost!;
+    }
+
+    private getCameraName(details: SimplisafeCameraDetails): string {
+        return details.cameraSettings?.cameraName || details.name || `Camera ${details.uuid}`;
+    }
+
+    private isUnsupported(details: SimplisafeCameraDetails): boolean {
+        return details.supportedFeatures?.providers?.recording !== undefined
+            && details.supportedFeatures.providers.recording !== 'simplisafe';
+    }
+}
+
+class SimplisafePlugin extends ScryptedDeviceBase implements DeviceProvider, Settings {
+    private readonly devices = new Map<string, SimplisafeCamera>();
+    private readonly cameraDetails = new Map<string, SimplisafeCameraDetails>();
+    private readonly authManager: SimplisafeAuthManager;
+    private readonly api: SimplisafeApi;
+    private debug: boolean;
+    private accountNumber?: string;
+    private initializing?: Promise<void>;
+
+    constructor() {
+        super();
+        this.debug = this.storage.getItem('debug') === 'true';
+        const storedAccount = this.storage.getItem('accountNumber');
+        this.accountNumber = storedAccount || undefined;
+
+        this.authManager = new SimplisafeAuthManager(this.storage, this.console, this.debug);
+        this.api = new SimplisafeApi(this.authManager, this.console, this.debug);
+        this.api.setAccountNumber(this.accountNumber);
+
+        this.loadCachedCameras();
+        this.initializing = this.initialize();
+    }
+
+    private async initialize(): Promise<void> {
+        if (!this.authManager.hasRefreshToken()) {
+            this.console.log('SimpliSafe plugin waiting for authentication. Configure credentials in the settings.');
+            return;
+        }
+
+        try {
+            await this.syncDevices();
+        } catch (err) {
+            this.console.error('Failed to initialize SimpliSafe cameras.', err);
+        }
+    }
+
+    private loadCachedCameras(): void {
+        const cached = this.storage.getItem('cameras');
+        if (!cached) {
+            return;
+        }
+
+        try {
+            const parsed: SimplisafeCameraDetails[] = JSON.parse(cached);
+            for (const camera of parsed) {
+                if (camera?.uuid) {
+                    this.cameraDetails.set(camera.uuid, camera);
+                }
+            }
+        } catch (err) {
+            this.console.warn('Failed to load cached camera data.', err);
+        }
+    }
+
+    async getDevice(nativeId: string): Promise<SimplisafeCamera> {
+        let device = this.devices.get(nativeId);
+        if (device) {
+            return device;
+        }
+
+        if (!this.cameraDetails.has(nativeId)) {
+            if (this.initializing) {
+                await this.initializing.catch(() => undefined);
+            }
+            if (!this.cameraDetails.has(nativeId)) {
+                await this.syncDevices();
+            }
+        }
+
+        const details = this.cameraDetails.get(nativeId);
+        if (!details) {
+            throw new Error(`Unknown SimpliSafe camera with native id ${nativeId}`);
+        }
+
+        device = new SimplisafeCamera(nativeId, this.api, this.authManager, () => this.debug);
+        device.updateDetails(details);
+        this.devices.set(nativeId, device);
+        return device;
+    }
+
+    async releaseDevice(id: string, nativeId: string): Promise<void> {
+        this.devices.delete(nativeId);
+    }
+
+    async getSettings(): Promise<Setting[]> {
+        const status = this.authManager.hasRefreshToken()
+            ? (this.authManager.isAuthenticated() ? 'Authenticated' : 'Refresh token stored, awaiting refresh')
+            : 'Not authenticated';
+
+        return [
+            {
+                key: 'loginUrl',
+                title: 'Login URL',
+                description: 'Open this URL to authenticate with SimpliSafe. Paste the final redirect URL below.',
+                value: this.authManager.getSSAuthURL(),
+                readonly: true,
+            },
+            {
+                key: 'authorizationCode',
+                title: 'Authorization Redirect URL',
+                description: 'After completing login, paste the entire redirect URL here to link your account.',
+                placeholder: 'com.simplisafe.mobile://auth...?',
+            },
+            {
+                key: 'refreshToken',
+                title: 'Refresh Token',
+                description: 'Optional: manually provide a refresh token obtained from another client.',
+                value: this.authManager.refreshToken,
+            },
+            {
+                key: 'accountNumber',
+                title: 'Account Number',
+                description: 'Required only if your SimpliSafe account has multiple monitoring plans.',
+                value: this.accountNumber,
+            },
+            {
+                key: 'debug',
+                title: 'Debug Logging',
+                description: 'Enable verbose logging for troubleshooting.',
+                type: 'boolean',
+                value: this.debug,
+            },
+            {
+                key: 'status',
+                title: 'Authentication Status',
+                readonly: true,
+                value: status,
+            },
+        ];
+    }
+
+    async putSetting(key: string, value: SettingValue): Promise<void> {
+        switch (key) {
+        case 'authorizationCode':
+            if (typeof value === 'string' && value.trim()) {
+                await this.handleAuthorization(value.trim());
+            }
+            break;
+        case 'refreshToken':
+            if (typeof value === 'string' && value.trim()) {
+                this.authManager.setRefreshToken(value.trim());
+                this.storage.setItem('refreshToken', value.trim());
+                try {
+                    await this.authManager.refreshCredentials();
+                } catch (err) {
+                    this.console.error('Failed to refresh credentials with provided refresh token.', err);
+                    throw err;
+                }
+            } else {
+                this.authManager.setRefreshToken(undefined);
+                this.storage.removeItem('refreshToken');
+            }
+            await this.syncDevices(true);
+            break;
+        case 'accountNumber':
+            if (typeof value === 'string' && value.trim()) {
+                this.accountNumber = value.trim();
+                this.storage.setItem('accountNumber', this.accountNumber);
+            } else {
+                this.accountNumber = undefined;
+                this.storage.removeItem('accountNumber');
+            }
+            this.api.setAccountNumber(this.accountNumber);
+            await this.syncDevices(true);
+            break;
+        case 'debug':
+            {
+                const debugEnabled = value === true || value === 'true';
+                this.debug = debugEnabled;
+                this.storage.setItem('debug', debugEnabled ? 'true' : 'false');
+                this.authManager.setDebug(debugEnabled);
+                this.api.setDebug(debugEnabled);
+                break;
+            }
+        default:
+            break;
+        }
+    }
+
+    private async handleAuthorization(redirectUrl: string): Promise<void> {
+        const accessToken = await this.authManager.getToken(redirectUrl);
+        if (!accessToken) {
+            throw new Error('SimpliSafe did not return an access token.');
+        }
+        await this.authManager.refreshCredentials();
+        await this.syncDevices(true);
+    }
+
+    private async syncDevices(forceRefresh = false): Promise<void> {
+        if (!this.authManager.hasRefreshToken()) {
+            return;
+        }
+
+        try {
+            const cameras = await this.api.getCameras(forceRefresh);
+            const devices: Device[] = [];
+            this.cameraDetails.clear();
+            for (const camera of cameras) {
+                this.cameraDetails.set(camera.uuid, camera);
+                devices.push({
+                    nativeId: camera.uuid,
+                    name: camera.cameraSettings?.cameraName || camera.name || `Camera ${camera.uuid}`,
+                    type: ScryptedDeviceType.Camera,
+                    interfaces: [
+                        ScryptedInterface.Camera,
+                        ScryptedInterface.VideoCamera,
+                    ],
+                    info: {
+                        manufacturer: 'SimpliSafe',
+                        model: camera.model,
+                        serialNumber: camera.uuid,
+                        firmware: camera.cameraSettings?.admin?.firmwareVersion,
+                    },
+                });
+            }
+
+            this.storage.setItem('cameras', JSON.stringify(cameras));
+            await deviceManager.onDevicesChanged({ devices });
+
+            for (const [id, device] of this.devices) {
+                const details = this.cameraDetails.get(id);
+                if (details) {
+                    device.updateDetails(details);
+                }
+            }
+        } catch (err) {
+            this.console.error('Failed to refresh SimpliSafe cameras.', err);
+            throw err;
+        }
+    }
+}
+
+export default SimplisafePlugin;

--- a/src/types/jpeg-extract.d.ts
+++ b/src/types/jpeg-extract.d.ts
@@ -1,0 +1,11 @@
+declare module 'jpeg-extract' {
+    import { RequestOptions } from 'https';
+
+    interface ExtractOptions extends RequestOptions {
+        url?: string;
+    }
+
+    function jpegExtract(options: ExtractOptions | string): Promise<Buffer>;
+
+    export default jpegExtract;
+}


### PR DESCRIPTION
## Summary
- implement SimpliSafe authentication, API helpers, and camera streaming support
- expose a SimpliSafe camera device provider with settings-driven discovery and configuration
- add jpeg-extract type declarations and required dependencies

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e617e8c2f4832abb41935a6ada5f70