### PR TITLE
HomeKit doorbell support, camera fixes, and startup reliability

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1627,13 +1627,6 @@ class SimplisafePlugin extends ScryptedDeviceBase implements DeviceProvider, Set
             || details.name
             || `Camera ${details.uuid ?? nativeId}`;
 
-        this.console.log(
-            `SimpliSafe refreshDeviceDescriptor: ${nativeId} ` +
-            `model=${details.model ?? 'unknown'} name=${details.name ?? 'unknown'} ` +
-            `doorbell=${doorbell} type=${doorbell ? ScryptedDeviceType.Doorbell : ScryptedDeviceType.Camera} ` +
-            `interfaces=[${interfaces.join(', ')}]`
-        );
-
         await this.publishCameraMeta(nativeId, {
             name,
             type: doorbell ? ScryptedDeviceType.Doorbell : ScryptedDeviceType.Camera,
@@ -1988,13 +1981,6 @@ class SimplisafePlugin extends ScryptedDeviceBase implements DeviceProvider, Set
             } else if (!doorbell && hasBinarySensor) {
                 interfaces = interfaces.filter(i => i !== ScryptedInterface.BinarySensor && i !== 'BinarySensor');
             }
-
-            this.console.log(
-                `SimpliSafe republishCachedDescriptors: ${descriptor.nativeId} ` +
-                `model=${details?.model ?? 'unknown'} name=${details?.name ?? descriptor.name} ` +
-                `doorbell=${doorbell} type=${correctedType} ` +
-                `interfaces=[${interfaces.join(', ')}]`
-            );
 
             devices.push({
                 nativeId: descriptor.nativeId,

--- a/src/main.ts
+++ b/src/main.ts
@@ -2133,8 +2133,9 @@ class SimplisafePlugin extends ScryptedDeviceBase implements DeviceProvider, Set
         }
         this.lastPublished.delete(normalized);
         this.readinessTasks.delete(normalized);
-        this.cachedDescriptors.delete(normalized);
-        this.persistCachedDescriptors();
+        // Do NOT delete from cachedDescriptors or persist here — Scrypted calls
+        // releaseDevice sequentially during shutdown, so persisting mid-shutdown
+        // would write a partial descriptor list and cause missing cameras on next boot.
         this.pendingRemoval.delete(normalized);
         this.schedulePersistCameraDetails();
     }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1581,10 +1581,10 @@ class SimplisafePlugin extends ScryptedDeviceBase implements DeviceProvider, Set
             return;
         }
 
-        const includeVideoCamera = this.upgradedNativeIds.has(nativeId);
         const doorbell = isDoorbellCamera(details);
         const interfaces: (ScryptedInterface | string)[] = [
             ScryptedInterface.Camera,
+            ScryptedInterface.VideoCamera,
             ScryptedInterface.Settings,
             RESOLUTION_INTERFACE,
             ScryptedInterface.Online,
@@ -1593,10 +1593,6 @@ class SimplisafePlugin extends ScryptedDeviceBase implements DeviceProvider, Set
 
         if (doorbell) {
             interfaces.push(ScryptedInterface.BinarySensor);
-        }
-
-        if (includeVideoCamera) {
-            interfaces.push(ScryptedInterface.VideoCamera);
         }
 
         const name = details.cameraSettings?.cameraName
@@ -1944,6 +1940,9 @@ class SimplisafePlugin extends ScryptedDeviceBase implements DeviceProvider, Set
             const correctedType = doorbell ? ScryptedDeviceType.Doorbell : ScryptedDeviceType.Camera;
 
             let interfaces = descriptor.interfaces;
+            if (!interfaces.includes(ScryptedInterface.VideoCamera) && !interfaces.includes('VideoCamera')) {
+                interfaces = [...interfaces, ScryptedInterface.VideoCamera];
+            }
             if (correctedType !== descriptor.type) {
                 interfaces = interfaces.filter(i => i !== ScryptedInterface.BinarySensor);
                 if (doorbell) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -1939,11 +1939,23 @@ class SimplisafePlugin extends ScryptedDeviceBase implements DeviceProvider, Set
 
         const devices: Device[] = [];
         for (const descriptor of this.cachedDescriptors.values()) {
+            const details = this.cameraDetails.get(descriptor.nativeId);
+            const doorbell = details ? isDoorbellCamera(details) : descriptor.type === ScryptedDeviceType.Doorbell;
+            const correctedType = doorbell ? ScryptedDeviceType.Doorbell : ScryptedDeviceType.Camera;
+
+            let interfaces = descriptor.interfaces;
+            if (correctedType !== descriptor.type) {
+                interfaces = interfaces.filter(i => i !== ScryptedInterface.BinarySensor);
+                if (doorbell) {
+                    interfaces = [...interfaces, ScryptedInterface.BinarySensor];
+                }
+            }
+
             devices.push({
                 nativeId: descriptor.nativeId,
                 name: descriptor.name,
-                type: descriptor.type,
-                interfaces: descriptor.interfaces,
+                type: correctedType,
+                interfaces,
                 info: descriptor.info,
             });
         }

--- a/src/main.ts
+++ b/src/main.ts
@@ -6,6 +6,7 @@
  */
 
 import sdk, {
+    BinarySensor,
     Camera,
     Device,
     DeviceState,
@@ -208,6 +209,12 @@ function buildPlaceholderCameraDetails(
         },
         supportedFeatures: existing?.supportedFeatures ?? {},
     };
+}
+
+function isDoorbellCamera(details: SimplisafeCameraDetails): boolean {
+    const model = (details.model ?? '').toLowerCase();
+    const name = (details.name ?? '').toLowerCase();
+    return model.includes('doorbell') || name.includes('doorbell');
 }
 
 class SimplisafeAuthManager extends EventEmitter {
@@ -889,7 +896,7 @@ class SimplisafeApi extends EventEmitter {
     }
 }
 
-class SimplisafeCamera extends ScryptedDeviceBase implements Camera, VideoCamera, Settings, MotionSensor {
+class SimplisafeCamera extends ScryptedDeviceBase implements Camera, VideoCamera, Settings, MotionSensor, BinarySensor {
     private static instanceRegistry = new Map<string, string>();
     private readonly nativeCameraId: string;
     private readonly api: SimplisafeApi;
@@ -910,6 +917,8 @@ class SimplisafeCamera extends ScryptedDeviceBase implements Camera, VideoCamera
     private readonly motionHoldDurationMs = 5_000;
     motionDetected?: boolean;
     motionDetectedTimestamp?: number;
+    private doorbellResetTimer?: NodeJS.Timeout;
+    private readonly doorbellHoldDurationMs = 5_000;
 
     constructor(
         nativeId: string,
@@ -955,6 +964,10 @@ class SimplisafeCamera extends ScryptedDeviceBase implements Camera, VideoCamera
         if (this.motionResetTimer) {
             clearTimeout(this.motionResetTimer);
             this.motionResetTimer = undefined;
+        }
+        if (this.doorbellResetTimer) {
+            clearTimeout(this.doorbellResetTimer);
+            this.doorbellResetTimer = undefined;
         }
     }
     updateDetails(details: SimplisafeCameraDetails): void {
@@ -1054,6 +1067,21 @@ class SimplisafeCamera extends ScryptedDeviceBase implements Camera, VideoCamera
             this.motionResetTimer = undefined;
             this.motionDetected = false;
         }, this.motionHoldDurationMs);
+    }
+
+    handleDoorbellEvent(event: SimplisafeRealtimeEvent): void {
+        this.logInstanceUsage('doorbellEvent');
+        if (this.getDebug()) {
+            this.console.log(`SimpliSafe doorbell press detected for ${this.nativeCameraId}.`);
+        }
+        this.binaryState = true;
+        if (this.doorbellResetTimer) {
+            clearTimeout(this.doorbellResetTimer);
+        }
+        this.doorbellResetTimer = setTimeout(() => {
+            this.doorbellResetTimer = undefined;
+            this.binaryState = false;
+        }, this.doorbellHoldDurationMs);
     }
 
     async prepareForStreaming(): Promise<boolean> {
@@ -1349,6 +1377,7 @@ class SimplisafePlugin extends ScryptedDeviceBase implements DeviceProvider, Set
         this.api = new SimplisafeApi(this.authManager, this.console, this.debug);
         this.api.setAccountNumber(this.accountNumber);
         this.api.on(EVENT_TYPES.CAMERA_MOTION, event => this.handleCameraMotionEvent(event));
+        this.api.on(EVENT_TYPES.DOORBELL, event => this.handleDoorbellPressEvent(event));
 
         this.loadCachedCameras();
         this.loadCameraReadiness();
@@ -1445,6 +1474,35 @@ class SimplisafePlugin extends ScryptedDeviceBase implements DeviceProvider, Set
         }
     }
 
+    private handleDoorbellPressEvent(event: SimplisafeRealtimeEvent): void {
+        const nativeIds = this.resolveNativeIdsFromEvent(event);
+        if (nativeIds.length === 0) {
+            if (this.debug) {
+                const identifier = event.sensorSerial
+                    || event.cameraSerial
+                    || event.serial
+                    || event.deviceSerial
+                    || event.cameraUuid
+                    || event.uuid;
+                this.console.warn(`SimpliSafe doorbell event could not be matched to a camera. identifier=${identifier ?? 'unknown'}`);
+            }
+            return;
+        }
+
+        for (const nativeId of nativeIds) {
+            void this.dispatchDoorbellEvent(nativeId, event);
+        }
+    }
+
+    private async dispatchDoorbellEvent(nativeId: string, event: SimplisafeRealtimeEvent): Promise<void> {
+        try {
+            const device = this.devices.get(nativeId) ?? await this.getDevice(nativeId);
+            device.handleDoorbellEvent(event);
+        } catch (err) {
+            this.console.warn(`SimpliSafe doorbell event dispatch failed for ${nativeId}.`, err);
+        }
+    }
+
     private async startRealtimeEvents(): Promise<void> {
         if (!this.authManager.hasRefreshToken()) {
             return;
@@ -1524,6 +1582,7 @@ class SimplisafePlugin extends ScryptedDeviceBase implements DeviceProvider, Set
         }
 
         const includeVideoCamera = this.upgradedNativeIds.has(nativeId);
+        const doorbell = isDoorbellCamera(details);
         const interfaces: (ScryptedInterface | string)[] = [
             ScryptedInterface.Camera,
             ScryptedInterface.Settings,
@@ -1531,6 +1590,10 @@ class SimplisafePlugin extends ScryptedDeviceBase implements DeviceProvider, Set
             ScryptedInterface.Online,
             ScryptedInterface.MotionSensor,
         ];
+
+        if (doorbell) {
+            interfaces.push(ScryptedInterface.BinarySensor);
+        }
 
         if (includeVideoCamera) {
             interfaces.push(ScryptedInterface.VideoCamera);
@@ -1542,7 +1605,7 @@ class SimplisafePlugin extends ScryptedDeviceBase implements DeviceProvider, Set
 
         await this.publishCameraMeta(nativeId, {
             name,
-            type: ScryptedDeviceType.Camera,
+            type: doorbell ? ScryptedDeviceType.Doorbell : ScryptedDeviceType.Camera,
             interfaces,
             info: {
                 manufacturer: 'SimpliSafe',

--- a/src/main.ts
+++ b/src/main.ts
@@ -211,10 +211,14 @@ function buildPlaceholderCameraDetails(
     };
 }
 
+// Known SimpliSafe doorbell model numbers (case-insensitive exact match).
+// SS002 = Video Doorbell Pro; more may be added as the product line grows.
+const SIMPLISAFE_DOORBELL_MODELS = new Set(['ss002']);
+
 function isDoorbellCamera(details: SimplisafeCameraDetails): boolean {
-    const model = (details.model ?? '').toLowerCase();
+    const model = (details.model ?? '').toLowerCase().trim();
     const name = (details.name ?? '').toLowerCase();
-    return model.includes('doorbell') || name.includes('doorbell');
+    return SIMPLISAFE_DOORBELL_MODELS.has(model) || model.includes('doorbell') || name.includes('doorbell');
 }
 
 class SimplisafeAuthManager extends EventEmitter {
@@ -1565,12 +1569,36 @@ class SimplisafePlugin extends ScryptedDeviceBase implements DeviceProvider, Set
             }
             return;
         }
+
+        // Stage the update in cachedDescriptors before publishing so that when
+        // we call onDevicesChanged we include ALL known cameras in one batch.
+        // onDevicesChanged replaces the plugin's entire child device list, so
+        // passing only the single updated device would erase all other cameras.
+        const previous = this.cachedDescriptors.get(normalized);
+        this.cachedDescriptors.set(normalized, cachedDescriptor);
+
+        const allDevices: Device[] = Array.from(this.cachedDescriptors.values()).map(d => {
+            const dev: Device = {
+                nativeId: d.nativeId,
+                name: d.name,
+                type: d.type,
+                interfaces: d.interfaces,
+            };
+            if (d.info) dev.info = d.info;
+            return dev;
+        });
+
         try {
-            await deviceManager.onDevicesChanged({ devices: [descriptor] });
+            await deviceManager.onDevicesChanged({ devices: allDevices });
             this.lastPublished.set(normalized, key);
-            this.cachedDescriptors.set(normalized, cachedDescriptor);
             this.persistCachedDescriptors();
         } catch (err) {
+            // Revert the staged update so cachedDescriptors stays consistent
+            if (previous) {
+                this.cachedDescriptors.set(normalized, previous);
+            } else {
+                this.cachedDescriptors.delete(normalized);
+            }
             this.console.warn(`Failed to publish SimpliSafe device descriptor for ${normalized}.`, err);
         }
     }
@@ -1598,6 +1626,13 @@ class SimplisafePlugin extends ScryptedDeviceBase implements DeviceProvider, Set
         const name = details.cameraSettings?.cameraName
             || details.name
             || `Camera ${details.uuid ?? nativeId}`;
+
+        this.console.log(
+            `SimpliSafe refreshDeviceDescriptor: ${nativeId} ` +
+            `model=${details.model ?? 'unknown'} name=${details.name ?? 'unknown'} ` +
+            `doorbell=${doorbell} type=${doorbell ? ScryptedDeviceType.Doorbell : ScryptedDeviceType.Camera} ` +
+            `interfaces=[${interfaces.join(', ')}]`
+        );
 
         await this.publishCameraMeta(nativeId, {
             name,
@@ -1943,12 +1978,23 @@ class SimplisafePlugin extends ScryptedDeviceBase implements DeviceProvider, Set
             if (!interfaces.includes(ScryptedInterface.VideoCamera) && !interfaces.includes('VideoCamera')) {
                 interfaces = [...interfaces, ScryptedInterface.VideoCamera];
             }
-            if (correctedType !== descriptor.type) {
-                interfaces = interfaces.filter(i => i !== ScryptedInterface.BinarySensor);
-                if (doorbell) {
-                    interfaces = [...interfaces, ScryptedInterface.BinarySensor];
-                }
+
+            // Always ensure BinarySensor is consistent with doorbell status regardless
+            // of whether the type changed — a cached descriptor could have type=Doorbell
+            // but be missing BinarySensor if it was persisted before BinarySensor was added.
+            const hasBinarySensor = interfaces.some(i => i === ScryptedInterface.BinarySensor || i === 'BinarySensor');
+            if (doorbell && !hasBinarySensor) {
+                interfaces = [...interfaces, ScryptedInterface.BinarySensor];
+            } else if (!doorbell && hasBinarySensor) {
+                interfaces = interfaces.filter(i => i !== ScryptedInterface.BinarySensor && i !== 'BinarySensor');
             }
+
+            this.console.log(
+                `SimpliSafe republishCachedDescriptors: ${descriptor.nativeId} ` +
+                `model=${details?.model ?? 'unknown'} name=${details?.name ?? descriptor.name} ` +
+                `doorbell=${doorbell} type=${correctedType} ` +
+                `interfaces=[${interfaces.join(', ')}]`
+            );
 
             devices.push({
                 nativeId: descriptor.nativeId,


### PR DESCRIPTION
## Summary

This PR bundles several HomeKit and reliability fixes:

**HomeKit doorbell support**
- Adds an `isDoorbellCamera` helper that detects cameras whose `model` or `name` contains \"doorbell\"
- Registers matching devices with `ScryptedDeviceType.Doorbell` and the `BinarySensor` interface
- Wires the WebSocket `DOORBELL` event (CID 1458) to `binaryState = true` on the matching device (auto-resets after 5 s), which Scrypted's HomeKit plugin maps to a doorbell press notification
- Fixes HomeKit not re-extending the doorbell type after a type transition on plugin restart (SS002 model detection edge case)

**Always advertise VideoCamera interface**
- Removes the readiness-probe gate so cameras advertise `VideoCamera` immediately on startup rather than waiting for the first successful snapshot, preventing HomeKit from dropping the camera stream endpoint

**Multi-camera `onDevicesChanged` batching**
- Fixes SS002 doorbell detection ensuring the correct camera type is published
- Batches `onDevicesChanged` calls so all cameras are registered in a single update (avoids partial lists overwriting each other)

**Fix alternating cameras on reboot**
- `releaseDevice` was deleting cameras from `cachedDescriptors` and calling `persistCachedDescriptors()` during shutdown
- Scrypted calls `releaseDevice` sequentially per camera, so if the process exits mid-shutdown the persisted list is partial — causing only one camera to appear on next boot and alternating which one each time
- Fix: skip the delete/persist in `releaseDevice`; the full descriptor list stays intact and `republishCachedDescriptors()` on next boot always sees all cameras

## Test plan

- [ ] Video Doorbell Pro appears as a Doorbell (not a Camera) in HomeKit after plugin restart
- [ ] Pressing the physical doorbell button triggers a HomeKit doorbell notification
- [ ] Non-doorbell cameras are unaffected (still registered as `Camera` type)
- [ ] Motion events on the doorbell camera still fire correctly
- [ ] Camera stream is available in HomeKit immediately after plugin restart without needing a snapshot first
- [ ] Reboot Scrypted multiple times and confirm all cameras appear consistently on each boot
- [ ] Cameras removed intentionally via the UI still disappear correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)