### PR TITLE
Livekit webrtc streaming

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,26 @@ An unofficial [Scrypted](https://github.com/koush/scrypted) plugin that connects
 
 ## Features
 - Discovers SimpliSafe cameras and registers them as Scrypted camera devices automatically.
-- Streams H.264 video (up to each camera's native resolution) with AAC audio suitable for HomeKit, Google Home, and other Scrypted integrations.
-- Emits motion events in real time so you can trigger automations the moment a camera detects motion or a doorbell rings.
+- Streams video from both camera generations: the legacy SimpliSafe cloud endpoint (H.264 + AAC over FLV) and the WebRTC/LiveKit transport used by newer cameras.
+- Two-way audio (talk-back) on LiveKit cameras, exposed through the Scrypted `Intercom` interface and usable from HomeKit.
+- Emits motion events in real time, and reports doorbell presses as a `BinarySensor` on doorbell models.
 - Maintains OAuth refresh tokens on your behalf and recovers gracefully from rate limits and transient API errors.
 - Optional verbose logging and device cleanup tools to help with troubleshooting.
+
+### Camera generations
+SimpliSafe ships two different streaming stacks, and the plugin picks one per camera based on the
+capabilities the API advertises:
+
+| | Legacy cameras | Newer cameras (LiveKit) |
+| --- | --- | --- |
+| Transport | SimpliSafe cloud FLV endpoint | WebRTC via LiveKit |
+| Scrypted interfaces | `VideoCamera` | `RTCSignalingChannel`, `Intercom` |
+| Two-way audio | No | Yes |
+
+LiveKit cameras deliberately do **not** advertise `VideoCamera` — the FLV endpoint returns nothing
+for them, so `getVideoStream` throws and only the WebRTC path works. Scrypted's WebRTC/rebroadcast
+plugins layer a `VideoCamera` mixin on top of `RTCSignalingChannel`, which is what downstream
+consumers such as HomeKit and Home Assistant actually use.
 
 ## Prerequisites
 - A running Scrypted server (local or hosted) with permission to install custom plugins.
@@ -40,7 +56,7 @@ An unofficial [Scrypted](https://github.com/koush/scrypted) plugin that connects
    - For production, run `npm run scrypted-deploy` to upload the compiled bundle.
 4. Open the Scrypted Admin Console, enable the **SimpliSafe Cameras** plugin, and complete authentication (see below).
 
-Once authenticated, the plugin will enumerate your cameras and create one Scrypted device per camera. Each device implements the `Camera`, `VideoCamera`, and `MotionSensor` interfaces.
+Once authenticated, the plugin will enumerate your cameras and create one Scrypted device per camera. Every device implements `Camera`, `Settings`, `Online`, and `MotionSensor`. The streaming interface depends on the camera generation (`VideoCamera` for legacy, `RTCSignalingChannel` + `Intercom` for LiveKit — see [Camera generations](#camera-generations)), and doorbell models additionally implement `BinarySensor`.
 
 ## Authentication
 SimpliSafe requires OAuth sign-in through their hosted login page. The flow mirrors the process documented by the [homebridge-simplisafe3](https://github.com/homebridge-simplisafe3/homebridge-simplisafe3) project and follows these steps:
@@ -63,7 +79,8 @@ If authentication fails, reset the **Authorization Redirect URL** field and repe
 
 ## Usage Notes
 - Camera live streams offer multiple resolutions based on the SimpliSafe quality settings. Scrypted clients will automatically pick the best match.
-- Motion events arrive via SimpliSafe's realtime websocket and map to the `MotionSensor` interface. Automations can filter on doorbell presses vs. motion using Scrypted scripting templates.
+- Motion events arrive via SimpliSafe's realtime websocket and map to the `MotionSensor` interface. Doorbell presses arrive on the same websocket and map to `BinarySensor`, so automations can distinguish a press from motion without scripting.
+- Talk-back on LiveKit cameras publishes a microphone track back to the camera over the existing WebRTC session. SimpliSafe expires a LiveKit session roughly every 10 minutes; the plugin pre-warms a replacement and rolls over, deferring the swap while talk-back is active so audio is not cut off mid-sentence.
 - The plugin caches camera metadata to survive short-term API outages. Toggle debug logging to review what the SimpliSafe API is returning.
 - Set the environment variable `SIMPLISAFE_DEV_CLEAN=1` when running `npm run dev:logs` to remove stale Scrypted device entries created during development.
 
@@ -74,6 +91,7 @@ If authentication fails, reset the **Authorization Redirect URL** field and repe
 
 ### Project structure
 - `src/main.ts` – Core plugin implementation: OAuth manager, API client, camera device classes, and realtime event handling.
+- `src/livekit.ts` – WebRTC/LiveKit transport for newer cameras: signalling, track forwarding into Scrypted's peer connection, keyframe caching for snapshots, session rollover, and the talk-back publisher.
 - `src/types` – Type stubs for third-party libraries used during snapshot extraction.
 
 Pull requests that improve stability, add new device types, or enhance logging are welcome. Please open an issue describing your use case before submitting significant changes.

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,9 +7,11 @@
       "": {
          "name": "@kylewhirl/scrypted-simplisafe",
          "version": "0.1.5",
-         "license": "Apache",
+         "license": "MIT",
          "dependencies": {
-            "@scrypted/sdk": "^0.5.46",
+            "@koush/werift": "^0.17.14",
+            "@livekit/protocol": "^1.48.2",
+            "@scrypted/sdk": "^0.5.29",
             "axios": "^1.7.7",
             "axios-retry": "^3.9.1",
             "jpeg-extract": "^3.0.1",
@@ -462,6 +464,12 @@
             "node": ">=6.9.0"
          }
       },
+      "node_modules/@bufbuild/protobuf": {
+         "version": "1.10.1",
+         "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-1.10.1.tgz",
+         "integrity": "sha512-wJ8ReQbHxsAfXhrf9ixl0aYbZorRuOWpBNzm8pL8ftmSxQx/wnJD5Eg861NwJU/czy2VXFIebCeZnZrI9rktIQ==",
+         "license": "(Apache-2.0 AND BSD-3-Clause)"
+      },
       "node_modules/@discoveryjs/json-ext": {
          "version": "0.5.7",
          "resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz",
@@ -470,6 +478,34 @@
          "engines": {
             "node": ">=10.0.0"
          }
+      },
+      "node_modules/@fidm/asn1": {
+         "version": "1.0.4",
+         "resolved": "https://registry.npmjs.org/@fidm/asn1/-/asn1-1.0.4.tgz",
+         "integrity": "sha512-esd1jyNvRb2HVaQGq2Gg8Z0kbQPXzV9Tq5Z14KNIov6KfFD6PTaRIO8UpcsYiTNzOqJpmyzWgVTrUwFV3UF4TQ==",
+         "license": "MIT",
+         "engines": {
+            "node": ">= 8"
+         }
+      },
+      "node_modules/@fidm/x509": {
+         "version": "1.2.1",
+         "resolved": "https://registry.npmjs.org/@fidm/x509/-/x509-1.2.1.tgz",
+         "integrity": "sha512-nwc2iesjyc9hkuzcrMCBXQRn653XuAUKorfWM8PZyJawiy1QzLj4vahwzaI25+pfpwOLvMzbJ0uKpWLDNmo16w==",
+         "license": "MIT",
+         "dependencies": {
+            "@fidm/asn1": "^1.0.4",
+            "tweetnacl": "^1.0.1"
+         },
+         "engines": {
+            "node": ">= 8"
+         }
+      },
+      "node_modules/@fidm/x509/node_modules/tweetnacl": {
+         "version": "1.0.3",
+         "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
+         "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==",
+         "license": "Unlicense"
       },
       "node_modules/@isaacs/cliui": {
          "version": "8.0.2",
@@ -531,6 +567,258 @@
          "dependencies": {
             "@jridgewell/resolve-uri": "^3.1.0",
             "@jridgewell/sourcemap-codec": "^1.4.14"
+         }
+      },
+      "node_modules/@koush/werift": {
+         "version": "0.17.14",
+         "resolved": "https://registry.npmjs.org/@koush/werift/-/werift-0.17.14.tgz",
+         "integrity": "sha512-36Ib/z3QrPwxAUtbhlXjEPIBWPGNQx5LUgpTrlafcjPNIX30UPPngA545y2VR78XjtQGHRBCcUcXp7BRXNpRZw==",
+         "license": "MIT",
+         "dependencies": {
+            "@fidm/x509": "^1.2.1",
+            "@minhducsun2002/leb128": "^1.0.0",
+            "@peculiar/webcrypto": "^1.4.1",
+            "@peculiar/x509": "^1.9.2",
+            "@shinyoshiaki/ebml-builder": "^0.0.1",
+            "aes-js": "^3.1.2",
+            "binary-data": "^0.6.0",
+            "buffer-crc32": "^0.2.13",
+            "date-fns": "^2.29.3",
+            "debug": "^4.3.4",
+            "elliptic": "^6.5.4",
+            "int64-buffer": "^1.0.1",
+            "ip": "^1.1.8",
+            "jspack": "^0.0.4",
+            "lodash": "^4.17.21",
+            "nano-time": "^1.0.0",
+            "p-cancelable": "^2.1.1",
+            "rx.mini": "^1.2.2",
+            "turbo-crc32": "^1.0.1",
+            "tweetnacl": "^1.0.3",
+            "uuid": "^9.0.0"
+         },
+         "engines": {
+            "node": ">=16"
+         }
+      },
+      "node_modules/@koush/werift/node_modules/tweetnacl": {
+         "version": "1.0.3",
+         "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
+         "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==",
+         "license": "Unlicense"
+      },
+      "node_modules/@koush/werift/node_modules/uuid": {
+         "version": "9.0.1",
+         "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+         "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+         "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+         "funding": [
+            "https://github.com/sponsors/broofa",
+            "https://github.com/sponsors/ctavan"
+         ],
+         "license": "MIT",
+         "bin": {
+            "uuid": "dist/bin/uuid"
+         }
+      },
+      "node_modules/@livekit/protocol": {
+         "version": "1.48.2",
+         "resolved": "https://registry.npmjs.org/@livekit/protocol/-/protocol-1.48.2.tgz",
+         "integrity": "sha512-xFcZdiVa4LpykarDZwdXbnS17qq+qbNKIT9v5/peNFNTjnMalmJkyo+XIIYfix6T9pG4LumjNzNBvxPEkIOrBg==",
+         "license": "Apache-2.0",
+         "dependencies": {
+            "@bufbuild/protobuf": "^1.10.0"
+         }
+      },
+      "node_modules/@minhducsun2002/leb128": {
+         "version": "1.0.0",
+         "resolved": "https://registry.npmjs.org/@minhducsun2002/leb128/-/leb128-1.0.0.tgz",
+         "integrity": "sha512-eFrYUPDVHeuwWHluTG1kwNQUEUcFjVKYwPkU8z9DR1JH3AW7JtJsG9cRVGmwz809kKtGfwGJj58juCZxEvnI/g==",
+         "license": "MIT"
+      },
+      "node_modules/@peculiar/asn1-cms": {
+         "version": "2.8.0",
+         "resolved": "https://registry.npmjs.org/@peculiar/asn1-cms/-/asn1-cms-2.8.0.tgz",
+         "integrity": "sha512-NgekZOrSJFSBFLFoLfwePguAWAx7z1+f2TEsWFUMyiqqfntZ4+S/S5hzqME3q4pCA0iOsFKdwiQ35dwY24eVqA==",
+         "license": "MIT",
+         "dependencies": {
+            "@peculiar/asn1-schema": "^2.8.0",
+            "@peculiar/asn1-x509": "^2.8.0",
+            "@peculiar/asn1-x509-attr": "^2.8.0",
+            "asn1js": "^3.0.10",
+            "tslib": "^2.8.1"
+         }
+      },
+      "node_modules/@peculiar/asn1-csr": {
+         "version": "2.8.0",
+         "resolved": "https://registry.npmjs.org/@peculiar/asn1-csr/-/asn1-csr-2.8.0.tgz",
+         "integrity": "sha512-akbF8+uvleHs8sejNPQxwmVFuInAg6FMNHOwMILXfP518YfFJwdR3jr6oNUPOaEJfuEhn/vkNOCIT6ASUd4mbg==",
+         "license": "MIT",
+         "dependencies": {
+            "@peculiar/asn1-schema": "^2.8.0",
+            "@peculiar/asn1-x509": "^2.8.0",
+            "asn1js": "^3.0.10",
+            "tslib": "^2.8.1"
+         }
+      },
+      "node_modules/@peculiar/asn1-ecc": {
+         "version": "2.8.0",
+         "resolved": "https://registry.npmjs.org/@peculiar/asn1-ecc/-/asn1-ecc-2.8.0.tgz",
+         "integrity": "sha512-ohwlk+u9Rv2NOAY1c6MfHj45ATVF8R1DUN/WCgABiRtLi2ZftlZWZX7KvpAbU8v9xPcmoILfELeEABj/rn18AQ==",
+         "license": "MIT",
+         "dependencies": {
+            "@peculiar/asn1-schema": "^2.8.0",
+            "@peculiar/asn1-x509": "^2.8.0",
+            "asn1js": "^3.0.10",
+            "tslib": "^2.8.1"
+         }
+      },
+      "node_modules/@peculiar/asn1-pfx": {
+         "version": "2.8.0",
+         "resolved": "https://registry.npmjs.org/@peculiar/asn1-pfx/-/asn1-pfx-2.8.0.tgz",
+         "integrity": "sha512-5yof1ytoB++RQtaFbqSUJ8pxDJtZT6vbVqZ8XoJ61ph7UjNVvfFwAilnCodqkNsAodpy13gDhoxZXw00pghnyg==",
+         "license": "MIT",
+         "dependencies": {
+            "@peculiar/asn1-cms": "^2.8.0",
+            "@peculiar/asn1-pkcs8": "^2.8.0",
+            "@peculiar/asn1-rsa": "^2.8.0",
+            "@peculiar/asn1-schema": "^2.8.0",
+            "asn1js": "^3.0.10",
+            "tslib": "^2.8.1"
+         }
+      },
+      "node_modules/@peculiar/asn1-pkcs8": {
+         "version": "2.8.0",
+         "resolved": "https://registry.npmjs.org/@peculiar/asn1-pkcs8/-/asn1-pkcs8-2.8.0.tgz",
+         "integrity": "sha512-qAKXtLpBEw9LqhKpjw3ajZSXlBur+ipW+y2ivVBQAG6F6qRx94yO+1ZR4mvw+YaCfKSaOzLeYEzsPaBp4SJELA==",
+         "license": "MIT",
+         "dependencies": {
+            "@peculiar/asn1-schema": "^2.8.0",
+            "@peculiar/asn1-x509": "^2.8.0",
+            "asn1js": "^3.0.10",
+            "tslib": "^2.8.1"
+         }
+      },
+      "node_modules/@peculiar/asn1-pkcs9": {
+         "version": "2.8.0",
+         "resolved": "https://registry.npmjs.org/@peculiar/asn1-pkcs9/-/asn1-pkcs9-2.8.0.tgz",
+         "integrity": "sha512-b5nDWCnkV60+cQ141D6sVVwK9nz64R5n3zSVnklGd+ECdkW2Ol3U1a6yYFlalpSOaD557yuJB64A+q42jG7lUQ==",
+         "license": "MIT",
+         "dependencies": {
+            "@peculiar/asn1-cms": "^2.8.0",
+            "@peculiar/asn1-pfx": "^2.8.0",
+            "@peculiar/asn1-pkcs8": "^2.8.0",
+            "@peculiar/asn1-schema": "^2.8.0",
+            "@peculiar/asn1-x509": "^2.8.0",
+            "@peculiar/asn1-x509-attr": "^2.8.0",
+            "asn1js": "^3.0.10",
+            "tslib": "^2.8.1"
+         }
+      },
+      "node_modules/@peculiar/asn1-rsa": {
+         "version": "2.8.0",
+         "resolved": "https://registry.npmjs.org/@peculiar/asn1-rsa/-/asn1-rsa-2.8.0.tgz",
+         "integrity": "sha512-zHEUlCqB2mk7x2lxDwHHJy7hWZOPdGHVlsmITWKB5/PbQo61atbu9PJ/0r9dQNMwFzbKPXZ8uK8/91eUhRznSg==",
+         "license": "MIT",
+         "dependencies": {
+            "@peculiar/asn1-schema": "^2.8.0",
+            "@peculiar/asn1-x509": "^2.8.0",
+            "asn1js": "^3.0.10",
+            "tslib": "^2.8.1"
+         }
+      },
+      "node_modules/@peculiar/asn1-schema": {
+         "version": "2.8.0",
+         "resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.8.0.tgz",
+         "integrity": "sha512-7YT0U/ze0tF2QOBbE15gKZwy5tvgGyLRiRHLzhlbOpf7BT032oBSd0haZqXn5W6l26WLlu3dyxzjM+2638/z2Q==",
+         "license": "MIT",
+         "dependencies": {
+            "@peculiar/utils": "^2.0.2",
+            "asn1js": "^3.0.10",
+            "tslib": "^2.8.1"
+         }
+      },
+      "node_modules/@peculiar/asn1-x509": {
+         "version": "2.8.0",
+         "resolved": "https://registry.npmjs.org/@peculiar/asn1-x509/-/asn1-x509-2.8.0.tgz",
+         "integrity": "sha512-N0CMuhWUzsWEVq6F1q9X6+VKUnWzSW+cSVg+aPaGGwDdbFoFWTYgin5MHwXgpWd6y9COMBxnfy/Qc+Xc7F0Zwg==",
+         "license": "MIT",
+         "dependencies": {
+            "@peculiar/asn1-schema": "^2.8.0",
+            "@peculiar/utils": "^2.0.2",
+            "asn1js": "^3.0.10",
+            "tslib": "^2.8.1"
+         }
+      },
+      "node_modules/@peculiar/asn1-x509-attr": {
+         "version": "2.8.0",
+         "resolved": "https://registry.npmjs.org/@peculiar/asn1-x509-attr/-/asn1-x509-attr-2.8.0.tgz",
+         "integrity": "sha512-tHjkfS/qhMnmrlB2J9NhflQlQ7In3khO3CfmVrriOlpTeErY9ZIKOso1hQ5JQiyrJ7ShvqVPk7E5fQmbclkSKA==",
+         "license": "MIT",
+         "dependencies": {
+            "@peculiar/asn1-schema": "^2.8.0",
+            "@peculiar/asn1-x509": "^2.8.0",
+            "asn1js": "^3.0.10",
+            "tslib": "^2.8.1"
+         }
+      },
+      "node_modules/@peculiar/json-schema": {
+         "version": "1.1.12",
+         "resolved": "https://registry.npmjs.org/@peculiar/json-schema/-/json-schema-1.1.12.tgz",
+         "integrity": "sha512-coUfuoMeIB7B8/NMekxaDzLhaYmp0HZNPEjYRm9goRou8UZIC3z21s0sL9AWoCw4EG876QyO3kYrc61WNF9B/w==",
+         "license": "MIT",
+         "dependencies": {
+            "tslib": "^2.0.0"
+         },
+         "engines": {
+            "node": ">=8.0.0"
+         }
+      },
+      "node_modules/@peculiar/utils": {
+         "version": "2.0.3",
+         "resolved": "https://registry.npmjs.org/@peculiar/utils/-/utils-2.0.3.tgz",
+         "integrity": "sha512-+oL3HPFRIZ1St2K50lWCXiioIgSoxzz7R1J3uF6neO2yl1sgmpgY6XXJH4BdpoDkMWznQTeYF6oWNDZLCdQ4eQ==",
+         "license": "MIT",
+         "dependencies": {
+            "tslib": "^2.8.1"
+         }
+      },
+      "node_modules/@peculiar/webcrypto": {
+         "version": "1.7.1",
+         "resolved": "https://registry.npmjs.org/@peculiar/webcrypto/-/webcrypto-1.7.1.tgz",
+         "integrity": "sha512-ODOov0sGMJMf3jPonOkgGqPknTsu+DdQ7kD++gz8aI+aFMOMHFbWAA2taqXXVTdP+OTOQR/znGvSpmkeI0WTYQ==",
+         "license": "MIT",
+         "dependencies": {
+            "@peculiar/asn1-schema": "^2.7.0",
+            "@peculiar/json-schema": "^1.1.12",
+            "@peculiar/utils": "^2.0.2",
+            "tslib": "^2.8.1",
+            "webcrypto-core": "^1.9.2"
+         },
+         "engines": {
+            "node": ">=14.18.0"
+         }
+      },
+      "node_modules/@peculiar/x509": {
+         "version": "1.14.3",
+         "resolved": "https://registry.npmjs.org/@peculiar/x509/-/x509-1.14.3.tgz",
+         "integrity": "sha512-C2Xj8FZ0uHWeCXXqX5B4/gVFQmtSkiuOolzAgutjTfseNOHT3pUjljDZsTSxXFGgio54bCzVFqmEOUrIVk8RDA==",
+         "license": "MIT",
+         "dependencies": {
+            "@peculiar/asn1-cms": "^2.6.0",
+            "@peculiar/asn1-csr": "^2.6.0",
+            "@peculiar/asn1-ecc": "^2.6.0",
+            "@peculiar/asn1-pkcs9": "^2.6.0",
+            "@peculiar/asn1-rsa": "^2.6.0",
+            "@peculiar/asn1-schema": "^2.6.0",
+            "@peculiar/asn1-x509": "^2.6.0",
+            "pvtsutils": "^1.3.6",
+            "reflect-metadata": "^0.2.2",
+            "tslib": "^2.8.1",
+            "tsyringe": "^4.10.0"
+         },
+         "engines": {
+            "node": ">=20.0.0"
          }
       },
       "node_modules/@polka/url": {
@@ -972,6 +1260,15 @@
             "scrypted-webpack": "bin/scrypted-webpack.js"
          }
       },
+      "node_modules/@shinyoshiaki/ebml-builder": {
+         "version": "0.0.1",
+         "resolved": "https://registry.npmjs.org/@shinyoshiaki/ebml-builder/-/ebml-builder-0.0.1.tgz",
+         "integrity": "sha512-rz1LklnlZ0yvVIt924yRGu+R87Fhfa06BdRIZR6GF6SXVSBTD9wCQmN6opXQLuSkoKXleWJwF3PW1ls8DGZjtw==",
+         "license": "MIT",
+         "dependencies": {
+            "lodash.memoize": "^4.1.2"
+         }
+      },
       "node_modules/@types/eslint": {
          "version": "9.6.1",
          "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-9.6.1.tgz",
@@ -1220,6 +1517,12 @@
             "node": ">=12.0"
          }
       },
+      "node_modules/aes-js": {
+         "version": "3.1.2",
+         "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-3.1.2.tgz",
+         "integrity": "sha512-e5pEa2kBnBOgR4Y/p20pskXI74UEz7de8ZGVo58asOtvSVG5YAbJeELPZxOmt+Bnz3rX753YKhfIn4X4l1PPRQ==",
+         "license": "MIT"
+      },
       "node_modules/ajv": {
          "version": "8.17.1",
          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
@@ -1299,6 +1602,20 @@
          "license": "MIT",
          "dependencies": {
             "safer-buffer": "~2.1.0"
+         }
+      },
+      "node_modules/asn1js": {
+         "version": "3.0.10",
+         "resolved": "https://registry.npmjs.org/asn1js/-/asn1js-3.0.10.tgz",
+         "integrity": "sha512-S2s3aOytiKdFRdulw2qPE51MzjzVOisppcVv7jVFR+Kw0kxwvFrDcYA0h7Ndqbmj0HkMIXYWaoj7fli8kgx1eg==",
+         "license": "BSD-3-Clause",
+         "dependencies": {
+            "pvtsutils": "^1.3.6",
+            "pvutils": "^1.1.5",
+            "tslib": "^2.8.1"
+         },
+         "engines": {
+            "node": ">=12.0.0"
          }
       },
       "node_modules/assert-plus": {
@@ -1397,6 +1714,15 @@
             "tweetnacl": "^0.14.3"
          }
       },
+      "node_modules/big-integer": {
+         "version": "1.6.52",
+         "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.52.tgz",
+         "integrity": "sha512-QxD8cf2eVqJOOz63z6JIN9BzvVs/dlySa5HGSBH5xtR8dPteIRQnBxxKqkNTiT6jbDTF6jAfrd4oMcND9RGbQg==",
+         "license": "Unlicense",
+         "engines": {
+            "node": ">=0.6"
+         }
+      },
       "node_modules/big.js": {
          "version": "5.2.2",
          "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
@@ -1405,6 +1731,25 @@
          "engines": {
             "node": "*"
          }
+      },
+      "node_modules/binary-data": {
+         "version": "0.6.0",
+         "resolved": "https://registry.npmjs.org/binary-data/-/binary-data-0.6.0.tgz",
+         "integrity": "sha512-HGiT0ir03tS1u7iWdW5xjJfbPpvxH2qJbPFxXW0I3P5iOzkbjN/cJy5GlpAwmjHW5CiayGOxZ/ytLzXmYgdgqQ==",
+         "license": "MIT",
+         "dependencies": {
+            "generate-function": "^2.3.1",
+            "is-plain-object": "^2.0.3"
+         },
+         "engines": {
+            "node": ">=6"
+         }
+      },
+      "node_modules/bn.js": {
+         "version": "4.12.4",
+         "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.4.tgz",
+         "integrity": "sha512-njR1b+ixG2ufvL9Zn9JGneW+b5GV6jqpYyPPpg4QVt723b5kJPGUczkUyWEH9BwEA74UakJZ43I4FDLBF7ci0g==",
+         "license": "MIT"
       },
       "node_modules/brace-expansion": {
          "version": "2.0.2",
@@ -1426,6 +1771,12 @@
          "engines": {
             "node": ">=8"
          }
+      },
+      "node_modules/brorand": {
+         "version": "1.1.0",
+         "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
+         "integrity": "sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w==",
+         "license": "MIT"
       },
       "node_modules/browserslist": {
          "version": "4.24.4",
@@ -1459,26 +1810,20 @@
             "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
          }
       },
+      "node_modules/buffer-crc32": {
+         "version": "0.2.13",
+         "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+         "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+         "license": "MIT",
+         "engines": {
+            "node": "*"
+         }
+      },
       "node_modules/buffer-from": {
          "version": "1.1.2",
          "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
          "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
          "license": "MIT"
-      },
-      "node_modules/bufferutil": {
-         "version": "4.0.8",
-         "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.0.8.tgz",
-         "integrity": "sha512-4T53u4PdgsXqKaIctwF8ifXlRTTmEPJ8iEPWFdGZvcf7sbwYo6FKFEX9eNNAnzFZ7EzJAQ3CJeOtCRA4rDp7Pw==",
-         "hasInstallScript": true,
-         "license": "MIT",
-         "optional": true,
-         "peer": true,
-         "dependencies": {
-            "node-gyp-build": "^4.3.0"
-         },
-         "engines": {
-            "node": ">=6.14.2"
-         }
       },
       "node_modules/call-bind-apply-helpers": {
          "version": "1.0.2",
@@ -1625,6 +1970,22 @@
             "node": ">=0.10"
          }
       },
+      "node_modules/date-fns": {
+         "version": "2.30.0",
+         "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
+         "integrity": "sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==",
+         "license": "MIT",
+         "dependencies": {
+            "@babel/runtime": "^7.21.0"
+         },
+         "engines": {
+            "node": ">=0.11"
+         },
+         "funding": {
+            "type": "opencollective",
+            "url": "https://opencollective.com/date-fns"
+         }
+      },
       "node_modules/debounce": {
          "version": "1.2.1",
          "resolved": "https://registry.npmjs.org/debounce/-/debounce-1.2.1.tgz",
@@ -1707,6 +2068,21 @@
          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.115.tgz",
          "integrity": "sha512-MN1nahVHAQMOz6dz6bNZ7apgqc9InZy7Ja4DBEVCTdeiUcegbyOYE9bi/f2Z/z6ZxLi0RxLpyJ3EGe+4h3w73A==",
          "license": "ISC"
+      },
+      "node_modules/elliptic": {
+         "version": "6.6.1",
+         "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.6.1.tgz",
+         "integrity": "sha512-RaddvvMatK2LJHqFJ+YA4WysVN5Ita9E35botqIYspQ4TkRAlCicdzKOjlyv/1Za5RyTNn7di//eEV0uTAfe3g==",
+         "license": "MIT",
+         "dependencies": {
+            "bn.js": "^4.11.9",
+            "brorand": "^1.1.0",
+            "hash.js": "^1.0.0",
+            "hmac-drbg": "^1.0.1",
+            "inherits": "^2.0.4",
+            "minimalistic-assert": "^1.0.1",
+            "minimalistic-crypto-utils": "^1.0.1"
+         }
       },
       "node_modules/emoji-regex": {
          "version": "9.2.2",
@@ -2035,6 +2411,15 @@
             "url": "https://github.com/sponsors/ljharb"
          }
       },
+      "node_modules/generate-function": {
+         "version": "2.3.1",
+         "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.3.1.tgz",
+         "integrity": "sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ==",
+         "license": "MIT",
+         "dependencies": {
+            "is-property": "^1.0.2"
+         }
+      },
       "node_modules/gensync": {
          "version": "1.0.0-beta.2",
          "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -2234,6 +2619,16 @@
             "url": "https://github.com/sponsors/ljharb"
          }
       },
+      "node_modules/hash.js": {
+         "version": "1.1.7",
+         "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
+         "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
+         "license": "MIT",
+         "dependencies": {
+            "inherits": "^2.0.3",
+            "minimalistic-assert": "^1.0.1"
+         }
+      },
       "node_modules/hasown": {
          "version": "2.0.2",
          "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
@@ -2244,6 +2639,17 @@
          },
          "engines": {
             "node": ">= 0.4"
+         }
+      },
+      "node_modules/hmac-drbg": {
+         "version": "1.0.1",
+         "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
+         "integrity": "sha512-Tti3gMqLdZfhOQY1Mzf/AanLiqh1WTiJgEj26ZuYQ9fbkLomzGchCws4FyrSd4VkpBfiNhaE1On+lOz894jvXg==",
+         "license": "MIT",
+         "dependencies": {
+            "hash.js": "^1.0.3",
+            "minimalistic-assert": "^1.0.0",
+            "minimalistic-crypto-utils": "^1.0.1"
          }
       },
       "node_modules/html-escaper": {
@@ -2266,6 +2672,24 @@
             "node": ">=0.8",
             "npm": ">=1.3.7"
          }
+      },
+      "node_modules/inherits": {
+         "version": "2.0.4",
+         "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+         "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+         "license": "ISC"
+      },
+      "node_modules/int64-buffer": {
+         "version": "1.1.0",
+         "resolved": "https://registry.npmjs.org/int64-buffer/-/int64-buffer-1.1.0.tgz",
+         "integrity": "sha512-94smTCQOvigN4d/2R/YDjz8YVG0Sufvv2aAh8P5m42gwhCsDAJqnbNOrxJsrADuAFAA69Q/ptGzxvNcNuIJcvw==",
+         "license": "MIT"
+      },
+      "node_modules/ip": {
+         "version": "1.1.9",
+         "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.9.tgz",
+         "integrity": "sha512-cyRxvOEpNHNtchU3Ln9KC/auJgup87llfQpQ+t5ghoC/UhL16SWzbueiCsdTnWmqAWl7LadfuwhlqmtOaqMHdQ==",
+         "license": "MIT"
       },
       "node_modules/is-core-module": {
          "version": "2.16.1",
@@ -2306,6 +2730,24 @@
             "node": ">=0.12.0"
          }
       },
+      "node_modules/is-plain-object": {
+         "version": "2.0.4",
+         "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+         "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+         "license": "MIT",
+         "dependencies": {
+            "isobject": "^3.0.1"
+         },
+         "engines": {
+            "node": ">=0.10.0"
+         }
+      },
+      "node_modules/is-property": {
+         "version": "1.0.2",
+         "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+         "integrity": "sha512-Ks/IoX00TtClbGQr4TWXemAnktAQvYB7HzcCxDGqEZU6oCmb2INHuOoKxbtR+HFkmYWBKv/dOZtGRiAjDhj92g==",
+         "license": "MIT"
+      },
       "node_modules/is-reference": {
          "version": "1.2.1",
          "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-1.2.1.tgz",
@@ -2338,6 +2780,15 @@
          "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
          "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
          "license": "ISC"
+      },
+      "node_modules/isobject": {
+         "version": "3.0.1",
+         "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+         "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
+         "license": "MIT",
+         "engines": {
+            "node": ">=0.10.0"
+         }
       },
       "node_modules/isstream": {
          "version": "0.1.2",
@@ -2458,6 +2909,11 @@
             "node": ">=6"
          }
       },
+      "node_modules/jspack": {
+         "version": "0.0.4",
+         "resolved": "https://registry.npmjs.org/jspack/-/jspack-0.0.4.tgz",
+         "integrity": "sha512-DC/lSTXYDDdYWzyY/9A1kMzp6Ov9mCRhZQ1cGg4te2w3y4/aKZTSspvbYN4LUsvSzMCb/H8z4TV9mYYW/bs3PQ=="
+      },
       "node_modules/jsprim": {
          "version": "1.4.2",
          "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.2.tgz",
@@ -2510,6 +2966,18 @@
          "funding": {
             "url": "https://github.com/sponsors/sindresorhus"
          }
+      },
+      "node_modules/lodash": {
+         "version": "4.18.1",
+         "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+         "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+         "license": "MIT"
+      },
+      "node_modules/lodash.memoize": {
+         "version": "4.1.2",
+         "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
+         "integrity": "sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==",
+         "license": "MIT"
       },
       "node_modules/magic-string": {
          "version": "0.30.17",
@@ -2581,6 +3049,18 @@
             "node": ">= 0.6"
          }
       },
+      "node_modules/minimalistic-assert": {
+         "version": "1.0.1",
+         "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+         "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
+         "license": "ISC"
+      },
+      "node_modules/minimalistic-crypto-utils": {
+         "version": "1.0.1",
+         "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
+         "integrity": "sha512-JIYlbt6g8i5jKfJ3xz7rF0LXmv2TkDxBLUkiBeZ7bAx4GnnNMr8xFpGnOxn6GhTEHx3SjRrZEoU+j04prX1ktg==",
+         "license": "MIT"
+      },
       "node_modules/minimatch": {
          "version": "10.0.1",
          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.0.1.tgz",
@@ -2620,6 +3100,15 @@
          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
          "license": "MIT"
       },
+      "node_modules/nano-time": {
+         "version": "1.0.0",
+         "resolved": "https://registry.npmjs.org/nano-time/-/nano-time-1.0.0.tgz",
+         "integrity": "sha512-flnngywOoQ0lLQOTRNexn2gGSNuM9bKj9RZAWSzhQ+UJYaAFG9bac4DW9VHjUAzrOaIcajHybCTHe/bkvozQqA==",
+         "license": "ISC",
+         "dependencies": {
+            "big-integer": "^1.6.16"
+         }
+      },
       "node_modules/ncp": {
          "version": "2.0.0",
          "resolved": "https://registry.npmjs.org/ncp/-/ncp-2.0.0.tgz",
@@ -2634,19 +3123,6 @@
          "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
          "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
          "license": "MIT"
-      },
-      "node_modules/node-gyp-build": {
-         "version": "4.8.4",
-         "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
-         "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
-         "license": "MIT",
-         "optional": true,
-         "peer": true,
-         "bin": {
-            "node-gyp-build": "bin.js",
-            "node-gyp-build-optional": "optional.js",
-            "node-gyp-build-test": "build-test.js"
-         }
       },
       "node_modules/node-releases": {
          "version": "2.0.19",
@@ -2691,6 +3167,15 @@
          "license": "(WTFPL OR MIT)",
          "bin": {
             "opener": "bin/opener-bin.js"
+         }
+      },
+      "node_modules/p-cancelable": {
+         "version": "2.1.1",
+         "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.1.1.tgz",
+         "integrity": "sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==",
+         "license": "MIT",
+         "engines": {
+            "node": ">=8"
          }
       },
       "node_modules/p-limit": {
@@ -2829,6 +3314,24 @@
             "node": ">=6"
          }
       },
+      "node_modules/pvtsutils": {
+         "version": "1.3.6",
+         "resolved": "https://registry.npmjs.org/pvtsutils/-/pvtsutils-1.3.6.tgz",
+         "integrity": "sha512-PLgQXQ6H2FWCaeRak8vvk1GW462lMxB5s3Jm673N82zI4vqtVUPuZdffdZbPDFRoU8kAhItWFtPCWiPpp4/EDg==",
+         "license": "MIT",
+         "dependencies": {
+            "tslib": "^2.8.1"
+         }
+      },
+      "node_modules/pvutils": {
+         "version": "1.1.5",
+         "resolved": "https://registry.npmjs.org/pvutils/-/pvutils-1.1.5.tgz",
+         "integrity": "sha512-KTqnxsgGiQ6ZAzZCVlJH5eOjSnvlyEgx1m8bkRJfOhmGRqfo5KLvmAlACQkrjEtOQ4B7wF9TdSLIs9O90MX9xA==",
+         "license": "MIT",
+         "engines": {
+            "node": ">=16.0.0"
+         }
+      },
       "node_modules/qs": {
          "version": "6.5.3",
          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.3.tgz",
@@ -2915,6 +3418,12 @@
             "type": "opencollective",
             "url": "https://opencollective.com/webpack"
          }
+      },
+      "node_modules/reflect-metadata": {
+         "version": "0.2.2",
+         "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
+         "integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==",
+         "license": "Apache-2.0"
       },
       "node_modules/request": {
          "version": "2.88.2",
@@ -3048,6 +3557,11 @@
             "@rollup/rollup-win32-x64-msvc": "4.44.2",
             "fsevents": "~2.3.2"
          }
+      },
+      "node_modules/rx.mini": {
+         "version": "1.4.0",
+         "resolved": "https://registry.npmjs.org/rx.mini/-/rx.mini-1.4.0.tgz",
+         "integrity": "sha512-8w5cSc1mwNja7fl465DXOkVvIOkpvh2GW4jo31nAIvX4WTXCsRnKJGUfiDBzWtYRInEcHAUYIZfzusjIrea8gA=="
       },
       "node_modules/safe-buffer": {
          "version": "5.2.1",
@@ -3474,6 +3988,24 @@
          "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
          "license": "0BSD"
       },
+      "node_modules/tsyringe": {
+         "version": "4.10.0",
+         "resolved": "https://registry.npmjs.org/tsyringe/-/tsyringe-4.10.0.tgz",
+         "integrity": "sha512-axr3IdNuVIxnaK5XGEUFTu3YmAQ6lllgrvqfEoR16g/HGnYY/6We4oWENtAnzK6/LpJ2ur9PAb80RBt7/U4ugw==",
+         "license": "MIT",
+         "dependencies": {
+            "tslib": "^1.9.3"
+         },
+         "engines": {
+            "node": ">= 6.0.0"
+         }
+      },
+      "node_modules/tsyringe/node_modules/tslib": {
+         "version": "1.14.1",
+         "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+         "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+         "license": "0BSD"
+      },
       "node_modules/tunnel-agent": {
          "version": "0.6.0",
          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
@@ -3484,6 +4016,15 @@
          },
          "engines": {
             "node": "*"
+         }
+      },
+      "node_modules/turbo-crc32": {
+         "version": "1.0.1",
+         "resolved": "https://registry.npmjs.org/turbo-crc32/-/turbo-crc32-1.0.1.tgz",
+         "integrity": "sha512-8yyRd1ZdNp+AQLGqi3lTaA2k81JjlIZOyFQEsi7GQWBgirnQOxjqVtDEbYHM2Z4yFdJ5AQw0fxBLLnDCl6RXoQ==",
+         "license": "MIT",
+         "engines": {
+            "node": ">=6"
          }
       },
       "node_modules/tweetnacl": {
@@ -3585,6 +4126,19 @@
          },
          "engines": {
             "node": ">=10.13.0"
+         }
+      },
+      "node_modules/webcrypto-core": {
+         "version": "1.9.2",
+         "resolved": "https://registry.npmjs.org/webcrypto-core/-/webcrypto-core-1.9.2.tgz",
+         "integrity": "sha512-gsXecm82UQNlTBURJGuqOWy1Ww08S3kZUcr3aOJS02Pk0xLtkfeUAVC0u0xhgdonFme80edSJUIJyuvL/7250Q==",
+         "license": "MIT",
+         "dependencies": {
+            "@peculiar/asn1-schema": "^2.7.0",
+            "@peculiar/json-schema": "^1.1.12",
+            "@peculiar/utils": "^2.0.2",
+            "asn1js": "^3.0.10",
+            "tslib": "^2.8.1"
          }
       },
       "node_modules/webpack": {
@@ -4136,10 +4690,36 @@
             "@babel/helper-validator-identifier": "^7.27.1"
          }
       },
+      "@bufbuild/protobuf": {
+         "version": "1.10.1",
+         "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-1.10.1.tgz",
+         "integrity": "sha512-wJ8ReQbHxsAfXhrf9ixl0aYbZorRuOWpBNzm8pL8ftmSxQx/wnJD5Eg861NwJU/czy2VXFIebCeZnZrI9rktIQ=="
+      },
       "@discoveryjs/json-ext": {
          "version": "0.5.7",
          "resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz",
          "integrity": "sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw=="
+      },
+      "@fidm/asn1": {
+         "version": "1.0.4",
+         "resolved": "https://registry.npmjs.org/@fidm/asn1/-/asn1-1.0.4.tgz",
+         "integrity": "sha512-esd1jyNvRb2HVaQGq2Gg8Z0kbQPXzV9Tq5Z14KNIov6KfFD6PTaRIO8UpcsYiTNzOqJpmyzWgVTrUwFV3UF4TQ=="
+      },
+      "@fidm/x509": {
+         "version": "1.2.1",
+         "resolved": "https://registry.npmjs.org/@fidm/x509/-/x509-1.2.1.tgz",
+         "integrity": "sha512-nwc2iesjyc9hkuzcrMCBXQRn653XuAUKorfWM8PZyJawiy1QzLj4vahwzaI25+pfpwOLvMzbJ0uKpWLDNmo16w==",
+         "requires": {
+            "@fidm/asn1": "^1.0.4",
+            "tweetnacl": "^1.0.1"
+         },
+         "dependencies": {
+            "tweetnacl": {
+               "version": "1.0.3",
+               "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
+               "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw=="
+            }
+         }
       },
       "@isaacs/cliui": {
          "version": "8.0.2",
@@ -4189,6 +4769,221 @@
          "requires": {
             "@jridgewell/resolve-uri": "^3.1.0",
             "@jridgewell/sourcemap-codec": "^1.4.14"
+         }
+      },
+      "@koush/werift": {
+         "version": "0.17.14",
+         "resolved": "https://registry.npmjs.org/@koush/werift/-/werift-0.17.14.tgz",
+         "integrity": "sha512-36Ib/z3QrPwxAUtbhlXjEPIBWPGNQx5LUgpTrlafcjPNIX30UPPngA545y2VR78XjtQGHRBCcUcXp7BRXNpRZw==",
+         "requires": {
+            "@fidm/x509": "^1.2.1",
+            "@minhducsun2002/leb128": "^1.0.0",
+            "@peculiar/webcrypto": "^1.4.1",
+            "@peculiar/x509": "^1.9.2",
+            "@shinyoshiaki/ebml-builder": "^0.0.1",
+            "aes-js": "^3.1.2",
+            "binary-data": "^0.6.0",
+            "buffer-crc32": "^0.2.13",
+            "date-fns": "^2.29.3",
+            "debug": "^4.3.4",
+            "elliptic": "^6.5.4",
+            "int64-buffer": "^1.0.1",
+            "ip": "^1.1.8",
+            "jspack": "^0.0.4",
+            "lodash": "^4.17.21",
+            "nano-time": "^1.0.0",
+            "p-cancelable": "^2.1.1",
+            "rx.mini": "^1.2.2",
+            "turbo-crc32": "^1.0.1",
+            "tweetnacl": "^1.0.3",
+            "uuid": "^9.0.0"
+         },
+         "dependencies": {
+            "tweetnacl": {
+               "version": "1.0.3",
+               "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
+               "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw=="
+            },
+            "uuid": {
+               "version": "9.0.1",
+               "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+               "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA=="
+            }
+         }
+      },
+      "@livekit/protocol": {
+         "version": "1.48.2",
+         "resolved": "https://registry.npmjs.org/@livekit/protocol/-/protocol-1.48.2.tgz",
+         "integrity": "sha512-xFcZdiVa4LpykarDZwdXbnS17qq+qbNKIT9v5/peNFNTjnMalmJkyo+XIIYfix6T9pG4LumjNzNBvxPEkIOrBg==",
+         "requires": {
+            "@bufbuild/protobuf": "^1.10.0"
+         }
+      },
+      "@minhducsun2002/leb128": {
+         "version": "1.0.0",
+         "resolved": "https://registry.npmjs.org/@minhducsun2002/leb128/-/leb128-1.0.0.tgz",
+         "integrity": "sha512-eFrYUPDVHeuwWHluTG1kwNQUEUcFjVKYwPkU8z9DR1JH3AW7JtJsG9cRVGmwz809kKtGfwGJj58juCZxEvnI/g=="
+      },
+      "@peculiar/asn1-cms": {
+         "version": "2.8.0",
+         "resolved": "https://registry.npmjs.org/@peculiar/asn1-cms/-/asn1-cms-2.8.0.tgz",
+         "integrity": "sha512-NgekZOrSJFSBFLFoLfwePguAWAx7z1+f2TEsWFUMyiqqfntZ4+S/S5hzqME3q4pCA0iOsFKdwiQ35dwY24eVqA==",
+         "requires": {
+            "@peculiar/asn1-schema": "^2.8.0",
+            "@peculiar/asn1-x509": "^2.8.0",
+            "@peculiar/asn1-x509-attr": "^2.8.0",
+            "asn1js": "^3.0.10",
+            "tslib": "^2.8.1"
+         }
+      },
+      "@peculiar/asn1-csr": {
+         "version": "2.8.0",
+         "resolved": "https://registry.npmjs.org/@peculiar/asn1-csr/-/asn1-csr-2.8.0.tgz",
+         "integrity": "sha512-akbF8+uvleHs8sejNPQxwmVFuInAg6FMNHOwMILXfP518YfFJwdR3jr6oNUPOaEJfuEhn/vkNOCIT6ASUd4mbg==",
+         "requires": {
+            "@peculiar/asn1-schema": "^2.8.0",
+            "@peculiar/asn1-x509": "^2.8.0",
+            "asn1js": "^3.0.10",
+            "tslib": "^2.8.1"
+         }
+      },
+      "@peculiar/asn1-ecc": {
+         "version": "2.8.0",
+         "resolved": "https://registry.npmjs.org/@peculiar/asn1-ecc/-/asn1-ecc-2.8.0.tgz",
+         "integrity": "sha512-ohwlk+u9Rv2NOAY1c6MfHj45ATVF8R1DUN/WCgABiRtLi2ZftlZWZX7KvpAbU8v9xPcmoILfELeEABj/rn18AQ==",
+         "requires": {
+            "@peculiar/asn1-schema": "^2.8.0",
+            "@peculiar/asn1-x509": "^2.8.0",
+            "asn1js": "^3.0.10",
+            "tslib": "^2.8.1"
+         }
+      },
+      "@peculiar/asn1-pfx": {
+         "version": "2.8.0",
+         "resolved": "https://registry.npmjs.org/@peculiar/asn1-pfx/-/asn1-pfx-2.8.0.tgz",
+         "integrity": "sha512-5yof1ytoB++RQtaFbqSUJ8pxDJtZT6vbVqZ8XoJ61ph7UjNVvfFwAilnCodqkNsAodpy13gDhoxZXw00pghnyg==",
+         "requires": {
+            "@peculiar/asn1-cms": "^2.8.0",
+            "@peculiar/asn1-pkcs8": "^2.8.0",
+            "@peculiar/asn1-rsa": "^2.8.0",
+            "@peculiar/asn1-schema": "^2.8.0",
+            "asn1js": "^3.0.10",
+            "tslib": "^2.8.1"
+         }
+      },
+      "@peculiar/asn1-pkcs8": {
+         "version": "2.8.0",
+         "resolved": "https://registry.npmjs.org/@peculiar/asn1-pkcs8/-/asn1-pkcs8-2.8.0.tgz",
+         "integrity": "sha512-qAKXtLpBEw9LqhKpjw3ajZSXlBur+ipW+y2ivVBQAG6F6qRx94yO+1ZR4mvw+YaCfKSaOzLeYEzsPaBp4SJELA==",
+         "requires": {
+            "@peculiar/asn1-schema": "^2.8.0",
+            "@peculiar/asn1-x509": "^2.8.0",
+            "asn1js": "^3.0.10",
+            "tslib": "^2.8.1"
+         }
+      },
+      "@peculiar/asn1-pkcs9": {
+         "version": "2.8.0",
+         "resolved": "https://registry.npmjs.org/@peculiar/asn1-pkcs9/-/asn1-pkcs9-2.8.0.tgz",
+         "integrity": "sha512-b5nDWCnkV60+cQ141D6sVVwK9nz64R5n3zSVnklGd+ECdkW2Ol3U1a6yYFlalpSOaD557yuJB64A+q42jG7lUQ==",
+         "requires": {
+            "@peculiar/asn1-cms": "^2.8.0",
+            "@peculiar/asn1-pfx": "^2.8.0",
+            "@peculiar/asn1-pkcs8": "^2.8.0",
+            "@peculiar/asn1-schema": "^2.8.0",
+            "@peculiar/asn1-x509": "^2.8.0",
+            "@peculiar/asn1-x509-attr": "^2.8.0",
+            "asn1js": "^3.0.10",
+            "tslib": "^2.8.1"
+         }
+      },
+      "@peculiar/asn1-rsa": {
+         "version": "2.8.0",
+         "resolved": "https://registry.npmjs.org/@peculiar/asn1-rsa/-/asn1-rsa-2.8.0.tgz",
+         "integrity": "sha512-zHEUlCqB2mk7x2lxDwHHJy7hWZOPdGHVlsmITWKB5/PbQo61atbu9PJ/0r9dQNMwFzbKPXZ8uK8/91eUhRznSg==",
+         "requires": {
+            "@peculiar/asn1-schema": "^2.8.0",
+            "@peculiar/asn1-x509": "^2.8.0",
+            "asn1js": "^3.0.10",
+            "tslib": "^2.8.1"
+         }
+      },
+      "@peculiar/asn1-schema": {
+         "version": "2.8.0",
+         "resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.8.0.tgz",
+         "integrity": "sha512-7YT0U/ze0tF2QOBbE15gKZwy5tvgGyLRiRHLzhlbOpf7BT032oBSd0haZqXn5W6l26WLlu3dyxzjM+2638/z2Q==",
+         "requires": {
+            "@peculiar/utils": "^2.0.2",
+            "asn1js": "^3.0.10",
+            "tslib": "^2.8.1"
+         }
+      },
+      "@peculiar/asn1-x509": {
+         "version": "2.8.0",
+         "resolved": "https://registry.npmjs.org/@peculiar/asn1-x509/-/asn1-x509-2.8.0.tgz",
+         "integrity": "sha512-N0CMuhWUzsWEVq6F1q9X6+VKUnWzSW+cSVg+aPaGGwDdbFoFWTYgin5MHwXgpWd6y9COMBxnfy/Qc+Xc7F0Zwg==",
+         "requires": {
+            "@peculiar/asn1-schema": "^2.8.0",
+            "@peculiar/utils": "^2.0.2",
+            "asn1js": "^3.0.10",
+            "tslib": "^2.8.1"
+         }
+      },
+      "@peculiar/asn1-x509-attr": {
+         "version": "2.8.0",
+         "resolved": "https://registry.npmjs.org/@peculiar/asn1-x509-attr/-/asn1-x509-attr-2.8.0.tgz",
+         "integrity": "sha512-tHjkfS/qhMnmrlB2J9NhflQlQ7In3khO3CfmVrriOlpTeErY9ZIKOso1hQ5JQiyrJ7ShvqVPk7E5fQmbclkSKA==",
+         "requires": {
+            "@peculiar/asn1-schema": "^2.8.0",
+            "@peculiar/asn1-x509": "^2.8.0",
+            "asn1js": "^3.0.10",
+            "tslib": "^2.8.1"
+         }
+      },
+      "@peculiar/json-schema": {
+         "version": "1.1.12",
+         "resolved": "https://registry.npmjs.org/@peculiar/json-schema/-/json-schema-1.1.12.tgz",
+         "integrity": "sha512-coUfuoMeIB7B8/NMekxaDzLhaYmp0HZNPEjYRm9goRou8UZIC3z21s0sL9AWoCw4EG876QyO3kYrc61WNF9B/w==",
+         "requires": {
+            "tslib": "^2.0.0"
+         }
+      },
+      "@peculiar/utils": {
+         "version": "2.0.3",
+         "resolved": "https://registry.npmjs.org/@peculiar/utils/-/utils-2.0.3.tgz",
+         "integrity": "sha512-+oL3HPFRIZ1St2K50lWCXiioIgSoxzz7R1J3uF6neO2yl1sgmpgY6XXJH4BdpoDkMWznQTeYF6oWNDZLCdQ4eQ==",
+         "requires": {
+            "tslib": "^2.8.1"
+         }
+      },
+      "@peculiar/webcrypto": {
+         "version": "1.7.1",
+         "resolved": "https://registry.npmjs.org/@peculiar/webcrypto/-/webcrypto-1.7.1.tgz",
+         "integrity": "sha512-ODOov0sGMJMf3jPonOkgGqPknTsu+DdQ7kD++gz8aI+aFMOMHFbWAA2taqXXVTdP+OTOQR/znGvSpmkeI0WTYQ==",
+         "requires": {
+            "@peculiar/asn1-schema": "^2.7.0",
+            "@peculiar/json-schema": "^1.1.12",
+            "@peculiar/utils": "^2.0.2",
+            "tslib": "^2.8.1",
+            "webcrypto-core": "^1.9.2"
+         }
+      },
+      "@peculiar/x509": {
+         "version": "1.14.3",
+         "resolved": "https://registry.npmjs.org/@peculiar/x509/-/x509-1.14.3.tgz",
+         "integrity": "sha512-C2Xj8FZ0uHWeCXXqX5B4/gVFQmtSkiuOolzAgutjTfseNOHT3pUjljDZsTSxXFGgio54bCzVFqmEOUrIVk8RDA==",
+         "requires": {
+            "@peculiar/asn1-cms": "^2.6.0",
+            "@peculiar/asn1-csr": "^2.6.0",
+            "@peculiar/asn1-ecc": "^2.6.0",
+            "@peculiar/asn1-pkcs9": "^2.6.0",
+            "@peculiar/asn1-rsa": "^2.6.0",
+            "@peculiar/asn1-schema": "^2.6.0",
+            "@peculiar/asn1-x509": "^2.6.0",
+            "pvtsutils": "^1.3.6",
+            "reflect-metadata": "^0.2.2",
+            "tslib": "^2.8.1",
+            "tsyringe": "^4.10.0"
          }
       },
       "@polka/url": {
@@ -4403,6 +5198,14 @@
             "webpack-bundle-analyzer": "^4.10.2"
          }
       },
+      "@shinyoshiaki/ebml-builder": {
+         "version": "0.0.1",
+         "resolved": "https://registry.npmjs.org/@shinyoshiaki/ebml-builder/-/ebml-builder-0.0.1.tgz",
+         "integrity": "sha512-rz1LklnlZ0yvVIt924yRGu+R87Fhfa06BdRIZR6GF6SXVSBTD9wCQmN6opXQLuSkoKXleWJwF3PW1ls8DGZjtw==",
+         "requires": {
+            "lodash.memoize": "^4.1.2"
+         }
+      },
       "@types/eslint": {
          "version": "9.6.1",
          "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-9.6.1.tgz",
@@ -4612,6 +5415,11 @@
          "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.16.tgz",
          "integrity": "sha512-TGw5yVi4saajsSEgz25grObGHEUaDrniwvA2qwSC060KfqGPdglhvPMA2lPIoxs3PQIItj2iag35fONcQqgUaQ=="
       },
+      "aes-js": {
+         "version": "3.1.2",
+         "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-3.1.2.tgz",
+         "integrity": "sha512-e5pEa2kBnBOgR4Y/p20pskXI74UEz7de8ZGVo58asOtvSVG5YAbJeELPZxOmt+Bnz3rX753YKhfIn4X4l1PPRQ=="
+      },
       "ajv": {
          "version": "8.17.1",
          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
@@ -4658,6 +5466,16 @@
          "integrity": "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==",
          "requires": {
             "safer-buffer": "~2.1.0"
+         }
+      },
+      "asn1js": {
+         "version": "3.0.10",
+         "resolved": "https://registry.npmjs.org/asn1js/-/asn1js-3.0.10.tgz",
+         "integrity": "sha512-S2s3aOytiKdFRdulw2qPE51MzjzVOisppcVv7jVFR+Kw0kxwvFrDcYA0h7Ndqbmj0HkMIXYWaoj7fli8kgx1eg==",
+         "requires": {
+            "pvtsutils": "^1.3.6",
+            "pvutils": "^1.1.5",
+            "tslib": "^2.8.1"
          }
       },
       "assert-plus": {
@@ -4730,10 +5548,29 @@
             "tweetnacl": "^0.14.3"
          }
       },
+      "big-integer": {
+         "version": "1.6.52",
+         "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.52.tgz",
+         "integrity": "sha512-QxD8cf2eVqJOOz63z6JIN9BzvVs/dlySa5HGSBH5xtR8dPteIRQnBxxKqkNTiT6jbDTF6jAfrd4oMcND9RGbQg=="
+      },
       "big.js": {
          "version": "5.2.2",
          "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
          "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ=="
+      },
+      "binary-data": {
+         "version": "0.6.0",
+         "resolved": "https://registry.npmjs.org/binary-data/-/binary-data-0.6.0.tgz",
+         "integrity": "sha512-HGiT0ir03tS1u7iWdW5xjJfbPpvxH2qJbPFxXW0I3P5iOzkbjN/cJy5GlpAwmjHW5CiayGOxZ/ytLzXmYgdgqQ==",
+         "requires": {
+            "generate-function": "^2.3.1",
+            "is-plain-object": "^2.0.3"
+         }
+      },
+      "bn.js": {
+         "version": "4.12.4",
+         "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.4.tgz",
+         "integrity": "sha512-njR1b+ixG2ufvL9Zn9JGneW+b5GV6jqpYyPPpg4QVt723b5kJPGUczkUyWEH9BwEA74UakJZ43I4FDLBF7ci0g=="
       },
       "brace-expansion": {
          "version": "2.0.2",
@@ -4751,6 +5588,11 @@
             "fill-range": "^7.1.1"
          }
       },
+      "brorand": {
+         "version": "1.1.0",
+         "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
+         "integrity": "sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w=="
+      },
       "browserslist": {
          "version": "4.24.4",
          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.4.tgz",
@@ -4762,20 +5604,15 @@
             "update-browserslist-db": "^1.1.1"
          }
       },
+      "buffer-crc32": {
+         "version": "0.2.13",
+         "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+         "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ=="
+      },
       "buffer-from": {
          "version": "1.1.2",
          "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
          "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
-      },
-      "bufferutil": {
-         "version": "4.0.8",
-         "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.0.8.tgz",
-         "integrity": "sha512-4T53u4PdgsXqKaIctwF8ifXlRTTmEPJ8iEPWFdGZvcf7sbwYo6FKFEX9eNNAnzFZ7EzJAQ3CJeOtCRA4rDp7Pw==",
-         "optional": true,
-         "peer": true,
-         "requires": {
-            "node-gyp-build": "^4.3.0"
-         }
       },
       "call-bind-apply-helpers": {
          "version": "1.0.2",
@@ -4870,6 +5707,14 @@
             "assert-plus": "^1.0.0"
          }
       },
+      "date-fns": {
+         "version": "2.30.0",
+         "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
+         "integrity": "sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==",
+         "requires": {
+            "@babel/runtime": "^7.21.0"
+         }
+      },
       "debounce": {
          "version": "1.2.1",
          "resolved": "https://registry.npmjs.org/debounce/-/debounce-1.2.1.tgz",
@@ -4926,6 +5771,20 @@
          "version": "1.5.115",
          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.115.tgz",
          "integrity": "sha512-MN1nahVHAQMOz6dz6bNZ7apgqc9InZy7Ja4DBEVCTdeiUcegbyOYE9bi/f2Z/z6ZxLi0RxLpyJ3EGe+4h3w73A=="
+      },
+      "elliptic": {
+         "version": "6.6.1",
+         "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.6.1.tgz",
+         "integrity": "sha512-RaddvvMatK2LJHqFJ+YA4WysVN5Ita9E35botqIYspQ4TkRAlCicdzKOjlyv/1Za5RyTNn7di//eEV0uTAfe3g==",
+         "requires": {
+            "bn.js": "^4.11.9",
+            "brorand": "^1.1.0",
+            "hash.js": "^1.0.0",
+            "hmac-drbg": "^1.0.1",
+            "inherits": "^2.0.4",
+            "minimalistic-assert": "^1.0.1",
+            "minimalistic-crypto-utils": "^1.0.1"
+         }
       },
       "emoji-regex": {
          "version": "9.2.2",
@@ -5119,6 +5978,14 @@
          "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
          "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="
       },
+      "generate-function": {
+         "version": "2.3.1",
+         "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.3.1.tgz",
+         "integrity": "sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ==",
+         "requires": {
+            "is-property": "^1.0.2"
+         }
+      },
       "gensync": {
          "version": "1.0.0-beta.2",
          "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -5245,12 +6112,31 @@
             "has-symbols": "^1.0.3"
          }
       },
+      "hash.js": {
+         "version": "1.1.7",
+         "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
+         "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
+         "requires": {
+            "inherits": "^2.0.3",
+            "minimalistic-assert": "^1.0.1"
+         }
+      },
       "hasown": {
          "version": "2.0.2",
          "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
          "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
          "requires": {
             "function-bind": "^1.1.2"
+         }
+      },
+      "hmac-drbg": {
+         "version": "1.0.1",
+         "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
+         "integrity": "sha512-Tti3gMqLdZfhOQY1Mzf/AanLiqh1WTiJgEj26ZuYQ9fbkLomzGchCws4FyrSd4VkpBfiNhaE1On+lOz894jvXg==",
+         "requires": {
+            "hash.js": "^1.0.3",
+            "minimalistic-assert": "^1.0.0",
+            "minimalistic-crypto-utils": "^1.0.1"
          }
       },
       "html-escaper": {
@@ -5267,6 +6153,21 @@
             "jsprim": "^1.2.2",
             "sshpk": "^1.7.0"
          }
+      },
+      "inherits": {
+         "version": "2.0.4",
+         "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+         "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+      },
+      "int64-buffer": {
+         "version": "1.1.0",
+         "resolved": "https://registry.npmjs.org/int64-buffer/-/int64-buffer-1.1.0.tgz",
+         "integrity": "sha512-94smTCQOvigN4d/2R/YDjz8YVG0Sufvv2aAh8P5m42gwhCsDAJqnbNOrxJsrADuAFAA69Q/ptGzxvNcNuIJcvw=="
+      },
+      "ip": {
+         "version": "1.1.9",
+         "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.9.tgz",
+         "integrity": "sha512-cyRxvOEpNHNtchU3Ln9KC/auJgup87llfQpQ+t5ghoC/UhL16SWzbueiCsdTnWmqAWl7LadfuwhlqmtOaqMHdQ=="
       },
       "is-core-module": {
          "version": "2.16.1",
@@ -5291,6 +6192,19 @@
          "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
          "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
       },
+      "is-plain-object": {
+         "version": "2.0.4",
+         "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+         "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+         "requires": {
+            "isobject": "^3.0.1"
+         }
+      },
+      "is-property": {
+         "version": "1.0.2",
+         "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+         "integrity": "sha512-Ks/IoX00TtClbGQr4TWXemAnktAQvYB7HzcCxDGqEZU6oCmb2INHuOoKxbtR+HFkmYWBKv/dOZtGRiAjDhj92g=="
+      },
       "is-reference": {
          "version": "1.2.1",
          "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-1.2.1.tgz",
@@ -5313,6 +6227,11 @@
          "version": "2.0.0",
          "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
          "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
+      },
+      "isobject": {
+         "version": "3.0.1",
+         "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+         "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg=="
       },
       "isstream": {
          "version": "0.1.2",
@@ -5395,6 +6314,11 @@
          "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
          "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="
       },
+      "jspack": {
+         "version": "0.0.4",
+         "resolved": "https://registry.npmjs.org/jspack/-/jspack-0.0.4.tgz",
+         "integrity": "sha512-DC/lSTXYDDdYWzyY/9A1kMzp6Ov9mCRhZQ1cGg4te2w3y4/aKZTSspvbYN4LUsvSzMCb/H8z4TV9mYYW/bs3PQ=="
+      },
       "jsprim": {
          "version": "1.4.2",
          "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.2.tgz",
@@ -5428,6 +6352,16 @@
          "requires": {
             "p-locate": "^5.0.0"
          }
+      },
+      "lodash": {
+         "version": "4.18.1",
+         "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+         "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q=="
+      },
+      "lodash.memoize": {
+         "version": "4.1.2",
+         "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
+         "integrity": "sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag=="
       },
       "magic-string": {
          "version": "0.30.17",
@@ -5476,6 +6410,16 @@
             "mime-db": "1.52.0"
          }
       },
+      "minimalistic-assert": {
+         "version": "1.0.1",
+         "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+         "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A=="
+      },
+      "minimalistic-crypto-utils": {
+         "version": "1.0.1",
+         "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
+         "integrity": "sha512-JIYlbt6g8i5jKfJ3xz7rF0LXmv2TkDxBLUkiBeZ7bAx4GnnNMr8xFpGnOxn6GhTEHx3SjRrZEoU+j04prX1ktg=="
+      },
       "minimatch": {
          "version": "10.0.1",
          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.0.1.tgz",
@@ -5499,6 +6443,14 @@
          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
       },
+      "nano-time": {
+         "version": "1.0.0",
+         "resolved": "https://registry.npmjs.org/nano-time/-/nano-time-1.0.0.tgz",
+         "integrity": "sha512-flnngywOoQ0lLQOTRNexn2gGSNuM9bKj9RZAWSzhQ+UJYaAFG9bac4DW9VHjUAzrOaIcajHybCTHe/bkvozQqA==",
+         "requires": {
+            "big-integer": "^1.6.16"
+         }
+      },
       "ncp": {
          "version": "2.0.0",
          "resolved": "https://registry.npmjs.org/ncp/-/ncp-2.0.0.tgz",
@@ -5508,13 +6460,6 @@
          "version": "2.6.2",
          "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
          "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw=="
-      },
-      "node-gyp-build": {
-         "version": "4.8.4",
-         "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
-         "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
-         "optional": true,
-         "peer": true
       },
       "node-releases": {
          "version": "2.0.19",
@@ -5536,6 +6481,11 @@
          "version": "1.5.2",
          "resolved": "https://registry.npmjs.org/opener/-/opener-1.5.2.tgz",
          "integrity": "sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A=="
+      },
+      "p-cancelable": {
+         "version": "2.1.1",
+         "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.1.1.tgz",
+         "integrity": "sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg=="
       },
       "p-limit": {
          "version": "3.1.0",
@@ -5622,6 +6572,19 @@
          "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
          "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="
       },
+      "pvtsutils": {
+         "version": "1.3.6",
+         "resolved": "https://registry.npmjs.org/pvtsutils/-/pvtsutils-1.3.6.tgz",
+         "integrity": "sha512-PLgQXQ6H2FWCaeRak8vvk1GW462lMxB5s3Jm673N82zI4vqtVUPuZdffdZbPDFRoU8kAhItWFtPCWiPpp4/EDg==",
+         "requires": {
+            "tslib": "^2.8.1"
+         }
+      },
+      "pvutils": {
+         "version": "1.1.5",
+         "resolved": "https://registry.npmjs.org/pvutils/-/pvutils-1.1.5.tgz",
+         "integrity": "sha512-KTqnxsgGiQ6ZAzZCVlJH5eOjSnvlyEgx1m8bkRJfOhmGRqfo5KLvmAlACQkrjEtOQ4B7wF9TdSLIs9O90MX9xA=="
+      },
       "qs": {
          "version": "6.5.3",
          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.3.tgz",
@@ -5677,6 +6640,11 @@
                }
             }
          }
+      },
+      "reflect-metadata": {
+         "version": "0.2.2",
+         "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
+         "integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q=="
       },
       "request": {
          "version": "2.88.2",
@@ -5769,6 +6737,11 @@
             "@types/estree": "1.0.8",
             "fsevents": "~2.3.2"
          }
+      },
+      "rx.mini": {
+         "version": "1.4.0",
+         "resolved": "https://registry.npmjs.org/rx.mini/-/rx.mini-1.4.0.tgz",
+         "integrity": "sha512-8w5cSc1mwNja7fl465DXOkVvIOkpvh2GW4jo31nAIvX4WTXCsRnKJGUfiDBzWtYRInEcHAUYIZfzusjIrea8gA=="
       },
       "safe-buffer": {
          "version": "5.2.1",
@@ -6024,6 +6997,21 @@
          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
          "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
       },
+      "tsyringe": {
+         "version": "4.10.0",
+         "resolved": "https://registry.npmjs.org/tsyringe/-/tsyringe-4.10.0.tgz",
+         "integrity": "sha512-axr3IdNuVIxnaK5XGEUFTu3YmAQ6lllgrvqfEoR16g/HGnYY/6We4oWENtAnzK6/LpJ2ur9PAb80RBt7/U4ugw==",
+         "requires": {
+            "tslib": "^1.9.3"
+         },
+         "dependencies": {
+            "tslib": {
+               "version": "1.14.1",
+               "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+               "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+         }
+      },
       "tunnel-agent": {
          "version": "0.6.0",
          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
@@ -6031,6 +7019,11 @@
          "requires": {
             "safe-buffer": "^5.0.1"
          }
+      },
+      "turbo-crc32": {
+         "version": "1.0.1",
+         "resolved": "https://registry.npmjs.org/turbo-crc32/-/turbo-crc32-1.0.1.tgz",
+         "integrity": "sha512-8yyRd1ZdNp+AQLGqi3lTaA2k81JjlIZOyFQEsi7GQWBgirnQOxjqVtDEbYHM2Z4yFdJ5AQw0fxBLLnDCl6RXoQ=="
       },
       "tweetnacl": {
          "version": "0.14.5",
@@ -6086,6 +7079,18 @@
          "requires": {
             "glob-to-regexp": "^0.4.1",
             "graceful-fs": "^4.1.2"
+         }
+      },
+      "webcrypto-core": {
+         "version": "1.9.2",
+         "resolved": "https://registry.npmjs.org/webcrypto-core/-/webcrypto-core-1.9.2.tgz",
+         "integrity": "sha512-gsXecm82UQNlTBURJGuqOWy1Ww08S3kZUcr3aOJS02Pk0xLtkfeUAVC0u0xhgdonFme80edSJUIJyuvL/7250Q==",
+         "requires": {
+            "@peculiar/asn1-schema": "^2.7.0",
+            "@peculiar/json-schema": "^1.1.12",
+            "@peculiar/utils": "^2.0.2",
+            "asn1js": "^3.0.10",
+            "tslib": "^2.8.1"
          }
       },
       "webpack": {

--- a/package.json
+++ b/package.json
@@ -50,11 +50,15 @@
       ]
    },
    "dependencies": {
+      "@livekit/protocol": "^1.48.2",
       "@scrypted/sdk": "^0.5.29",
       "axios": "^1.7.7",
       "axios-retry": "^3.9.1",
       "jpeg-extract": "^3.0.1",
       "ws": "^8.18.0"
+   },
+   "optionalDependencies": {
+      "@koush/werift": "^0.17.14"
    },
    "devDependencies": {
       "@types/node": "^24.0.10",

--- a/src/livekit.ts
+++ b/src/livekit.ts
@@ -319,6 +319,8 @@ interface LiveKitViewer {
      * monotonic counters so the stream stays continuous across consumer-session (source) switches.
      */
     writeMic: (rtp: RtpPacket) => void;
+    /** True while a talk-back session currently owns the mic (and briefly after it goes idle). */
+    isMicActive: () => boolean;
 }
 
 /**
@@ -910,6 +912,7 @@ async function startLiveKitViewer(details: LiveKitDetails, console: ConsoleLike,
         ensureMicTrack,
         claimMic,
         writeMic,
+        isMicActive: () => !!micOwner,
     };
 }
 
@@ -1041,6 +1044,9 @@ export class LiveKitCameraStream {
     private activeGen = 0;
     private rolloverTimer?: NodeJS.Timeout;
     private streamEndedCbs: (() => void)[] = [];
+    // Outstanding device-level Intercom holds (acquireMicSink). These write to the mic track
+    // directly without claiming it, so they count as talk-back activity for rollover deferral.
+    private micSinkHolds = 0;
 
     constructor(
         private getDetails: () => Promise<LiveKitDetails>,
@@ -1136,6 +1142,22 @@ export class LiveKitCameraStream {
     private async rollover(oldViewer: LiveKitViewer): Promise<void> {
         if (this.viewer !== oldViewer || this.refcount === 0)
             return;
+        // Defer while talk-back is in progress — the shared mic track lives on the old session, so
+        // rolling over mid-talk cuts it off. Re-check every couple seconds until a drop-dead point
+        // that still leaves time to pre-warm the replacement before the server kills the old
+        // session at token expiry (at which point the talk would die anyway).
+        if (oldViewer.isMicActive() || this.micSinkHolds > 0) {
+            const dropDeadMs = (oldViewer.tokenExp ?? 0) * 1000 - 12_000;
+            if (Date.now() < dropDeadMs) {
+                this.dlog('SS:LiveKit rollover deferred: talk-back in progress.');
+                this.rolloverTimer = setTimeout(() => {
+                    this.rollover(oldViewer).catch(err =>
+                        this.dlog('SS:LiveKit rollover failed; session rides to expiry and self-heals.', err));
+                }, 2000);
+                return;
+            }
+            this.dlog('SS:LiveKit rollover proceeding despite active talk-back: token expiry imminent.');
+        }
         this.dlog('SS:LiveKit rollover: pre-warming replacement session before token expiry.');
         const details = await this.getDetails();
         const next = await startLiveKitViewer(details, this.console, this.debug, this.makeSinks(++this.genCounter));
@@ -1214,11 +1236,13 @@ export class LiveKitCameraStream {
     async acquireMicSink(): Promise<{ track: MediaStreamTrack; release: () => void }> {
         const viewer = await this.ensureViewer();
         this.refcount++;
+        this.micSinkHolds++;
         let released = false;
         const release = () => {
             if (released)
                 return;
             released = true;
+            this.micSinkHolds = Math.max(0, this.micSinkHolds - 1);
             this.release();
         };
         try {

--- a/src/livekit.ts
+++ b/src/livekit.ts
@@ -89,6 +89,7 @@ import {
     SignalRequest,
     SignalResponse,
     SignalTarget,
+    StreamState,
     TrackSource,
     TrackType,
     TrickleRequest,
@@ -284,9 +285,19 @@ class RtpSeqStats {
 }
 
 interface LiveKitViewer {
-    pc: RTCPeerConnection;
-    videoTrack?: MediaStreamTrack;
-    audioTrack?: MediaStreamTrack;
+    /** Negotiated codec parameters (stable across sessions — the payload-type mapping is forced). */
+    videoCodec?: RTCRtpCodecParameters;
+    audioCodec?: RTCRtpCodecParameters;
+    /**
+     * Expiry (unix seconds) of the token this session joined with. SimpliSafe's server enforces it:
+     * media stops at exp and a leave follows. LiveKitCameraStream pre-warms a replacement session
+     * shortly before this deadline and switches consumers over.
+     */
+    tokenExp?: number;
+    /** False once the viewer is torn down or its current peer connection failed. */
+    isHealthy: () => boolean;
+    /** Register a callback fired exactly when the viewer is torn down (leave/expiry/failure). */
+    onClosed: (cb: () => void) => void;
     close: () => void;
     /** The most recent decode-ready H264 keyframe (Annex-B SPS+PPS+IDR), if any has been seen. */
     getKeyframe: () => Buffer | undefined;
@@ -314,8 +325,73 @@ interface LiveKitViewer {
  * Connect to LiveKit as a subscriber and return the negotiated peer connection plus the received
  * media tracks.
  */
-async function startLiveKitViewer(details: LiveKitDetails, console: ConsoleLike, debug: () => boolean): Promise<LiveKitViewer> {
+/**
+ * Rewrites RTP sequence numbers and timestamps so that packets from successive sources (the
+ * subscriber peer connection is rebuilt on every session resume, with fresh SSRC/seq/ts bases)
+ * form one continuous stream. Offsets are constant per source, so intra-source ordering, gaps,
+ * and retransmissions are preserved; across a source switch the output continues just after the
+ * previous source's last packet, advanced by wall-clock elapsed time.
+ */
+class RtpRebaser {
+    private gen = -1;
+    private seqOffset = 0;
+    private tsOffset = 0;
+    private lastOutSeq = 0;
+    private lastOutTs = 0;
+    private lastWallMs = 0;
+    private started = false;
+
+    constructor(private clockRate: number) {
+    }
+
+    rebase(gen: number, rtp: RtpPacket): RtpPacket {
+        const header = rtp.header;
+        if (gen !== this.gen) {
+            this.gen = gen;
+            if (this.started) {
+                const elapsedMs = Math.max(20, Date.now() - this.lastWallMs);
+                const tsAdvance = Math.round(elapsedMs * this.clockRate / 1000);
+                // Margin past the last emitted seq guards against a slightly stale anchor (late
+                // retransmits can move lastOutSeq backwards a few packets).
+                this.seqOffset = (this.lastOutSeq + 16 - header.sequenceNumber) & 0xffff;
+                this.tsOffset = ((this.lastOutTs + tsAdvance - header.timestamp) >>> 0);
+            }
+        }
+        this.started = true;
+        header.sequenceNumber = (header.sequenceNumber + this.seqOffset) & 0xffff;
+        header.timestamp = (header.timestamp + this.tsOffset) >>> 0;
+        this.lastOutSeq = header.sequenceNumber;
+        this.lastOutTs = header.timestamp;
+        this.lastWallMs = Date.now();
+        return rtp;
+    }
+}
+
+// Decode a JWT's payload without verifying (diagnostics only — identity/expiry of LiveKit tokens).
+function jwtClaims(token: string): any {
+    try {
+        return JSON.parse(Buffer.from(token.split('.')[1], 'base64').toString());
+    }
+    catch {
+        return undefined;
+    }
+}
+
+/**
+ * RTP sinks a viewer delivers its received media into. Provided by LiveKitCameraStream, which owns
+ * the stable consumer-facing relays and switches the active source viewer across session rollovers.
+ */
+interface ViewerSinks {
+    video: (rtp: RtpPacket) => void;
+    audio: (rtp: RtpPacket) => void;
+}
+
+async function startLiveKitViewer(details: LiveKitDetails, console: ConsoleLike, debug: () => boolean, sinks: ViewerSinks): Promise<LiveKitViewer> {
     const dlog = (...args: any[]) => { if (debug()) console.log(...args); };
+    const joinClaims = jwtClaims(details.userToken);
+    if (joinClaims)
+        dlog(`SS:LiveKit join token claims sub=${joinClaims.sub} jti=${joinClaims.jti} room=${joinClaims.video?.room}`
+            + ` nbf=${joinClaims.nbf} exp=${joinClaims.exp} ttl=${joinClaims.exp - joinClaims.nbf}s`);
     const base = details.liveKitURL.replace(/\/$/, '');
     const params = new URLSearchParams({
         access_token: details.userToken,
@@ -333,27 +409,48 @@ async function startLiveKitViewer(details: LiveKitDetails, console: ConsoleLike,
     let videoTrack: MediaStreamTrack | undefined;
     let audioTrack: MediaStreamTrack | undefined;
     const keyframeCapturer = new H264KeyframeCapturer();
+    const closedCallbacks: (() => void)[] = [];
     // Packet-loss diagnostics: sequence continuity at the earliest point we see LiveKit RTP.
     const videoStats = new RtpSeqStats();
     const audioStats = new RtpSeqStats();
     let nackSends = 0;
     let statsTimer: NodeJS.Timeout | undefined;
     let lastStatsLine = '';
+    // Dead-window diagnostics: the upstream feed intermittently stops delivering video RTP for
+    // multiple seconds (kills long-lived downstream sessions like HA/rebroadcast clients). Track
+    // the last video packet arrival and log the exact start/end of any multi-second gap so it can
+    // be correlated with signaling events (streamStateUpdate, mute, renegotiation) and pc state.
+    const ts = () => new Date().toISOString().slice(11, 23);
+    let lastVideoRtpMs = 0;
+    let videoGapFlaggedAt = 0;
+    let gapTimer: NodeJS.Timeout | undefined;
     const startStatsLogging = () => {
         if (statsTimer)
             return;
         statsTimer = setInterval(() => {
+            const vidAge = lastVideoRtpMs ? Date.now() - lastVideoRtpMs : -1;
             const line = `SS:rtpstats video recv=${videoStats.received} lost=${videoStats.lost} gaps=${videoStats.gapEvents} late=${videoStats.reordered}`
                 + ` | audio recv=${audioStats.received} lost=${audioStats.lost}`
                 + ` | nackSends=${nackSends}`;
             if (line !== lastStatsLine) {
                 lastStatsLine = line;
-                dlog(line);
+                dlog(`${line} | vidAge=${vidAge}ms at ${ts()}`);
             }
         }, 10_000);
+        gapTimer = setInterval(() => {
+            if (!lastVideoRtpMs || videoGapFlaggedAt)
+                return;
+            const silentMs = Date.now() - lastVideoRtpMs;
+            if (silentMs > 1500) {
+                videoGapFlaggedAt = lastVideoRtpMs;
+                dlog(`SS:rtpgap video silent ${(silentMs / 1000).toFixed(1)}s at ${ts()}`
+                    + ` (pc=${pc?.connectionState}/${pc?.iceConnectionState})`);
+            }
+        }, 500);
     };
     let pingTimer: NodeJS.Timeout | undefined;
     let remoteDescriptionSet = false;
+    let closed = false;
     const pendingCandidates: RTCIceCandidate[] = [];
 
     // Publisher (outbound) peer connection state, created lazily when the first mic track is
@@ -408,15 +505,21 @@ async function startLiveKitViewer(details: LiveKitDetails, console: ConsoleLike,
     };
 
     const cleanup = () => {
+        closed = true;
         if (pingTimer)
             clearInterval(pingTimer);
         if (statsTimer)
             clearInterval(statsTimer);
+        if (gapTimer)
+            clearInterval(gapTimer);
         if (micMuteTimer)
             clearTimeout(micMuteTimer);
         try { ws.close(); } catch { /* ignore */ }
         try { pc?.close(); } catch { /* ignore */ }
         try { publisherPc?.close(); } catch { /* ignore */ }
+        for (const cb of closedCallbacks.splice(0)) {
+            try { cb(); } catch { /* ignore */ }
+        }
     };
 
     const send = (message: SignalRequest['message']) => {
@@ -447,19 +550,33 @@ async function startLiveKitViewer(details: LiveKitDetails, console: ConsoleLike,
             });
         });
 
+        pc.connectionStateChange.subscribe(state =>
+            dlog(`SS:LiveKit subscriber pc ${state} at ${ts()}`));
+        pc.iceConnectionStateChange.subscribe(state =>
+            dlog(`SS:LiveKit subscriber ice ${state} at ${ts()}`));
+
+        const myPc = pc;
         pc.onTrack.subscribe(track => {
             if (track.kind === 'video') {
                 videoTrack = track;
-                // Passively watch the video RTP to retain the latest keyframe for on-demand snapshots.
                 track.onReceiveRtp.subscribe(rtp => {
+                    const now = Date.now();
+                    if (videoGapFlaggedAt) {
+                        dlog(`SS:rtpgap video resumed after ${((now - videoGapFlaggedAt) / 1000).toFixed(1)}s at ${ts()}`);
+                        videoGapFlaggedAt = 0;
+                    }
+                    lastVideoRtpMs = now;
                     videoStats.onPacket(rtp.header.sequenceNumber);
+                    // Retain the latest keyframe (for on-demand snapshots), then hand the packet to
+                    // the stream-level sink (which rebases seq/ts across session rollovers).
                     try { keyframeCapturer.onRtp(rtp); }
                     catch { /* ignore malformed packet */ }
+                    sinks.video(rtp);
                 });
                 // Observe werift's NACK handler so the stats show whether retransmission requests
                 // are actually being sent for the gaps we see.
                 try {
-                    const receiver = (pc!.getTransceivers() as any[])
+                    const receiver = (myPc.getTransceivers() as any[])
                         .find(t => t?.receiver?.tracks?.includes?.(track) || t?.kind === 'video')?.receiver;
                     if (receiver) {
                         dlog('SS:rtpstats video nackEnabled=', !!receiver.nackEnabled);
@@ -473,7 +590,10 @@ async function startLiveKitViewer(details: LiveKitDetails, console: ConsoleLike,
             }
             else if (track.kind === 'audio') {
                 audioTrack = track;
-                track.onReceiveRtp.subscribe(rtp => audioStats.onPacket(rtp.header.sequenceNumber));
+                track.onReceiveRtp.subscribe(rtp => {
+                    audioStats.onPacket(rtp.header.sequenceNumber);
+                    sinks.audio(rtp);
+                });
                 startStatsLogging();
             }
         });
@@ -499,7 +619,8 @@ async function startLiveKitViewer(details: LiveKitDetails, console: ConsoleLike,
                 case 'join': {
                     const join = msg.value;
                     dlog('SS:LiveKit join subscriberPrimary=', join.subscriberPrimary,
-                        'iceServers=', join.iceServers?.length, 'pingInterval=', join.pingInterval);
+                        'iceServers=', join.iceServers?.length, 'pingInterval=', join.pingInterval,
+                        'sid=', join.participant?.sid);
                     joinIceServers = join.iceServers as any[];
                     setupPeerConnection(join.iceServers as any[]);
                     const intervalMs = (join.pingInterval || 30) * 1000;
@@ -592,11 +713,44 @@ async function startLiveKitViewer(details: LiveKitDetails, console: ConsoleLike,
                     if (msg.value.track?.type === TrackType.AUDIO && msg.value.track?.sid)
                         micSid = msg.value.track.sid;
                     break;
-                case 'leave':
-                    dlog('SS:LiveKit server requested leave.');
+                case 'leave': {
+                    const l = msg.value;
+                    dlog(`SS:LiveKit server requested leave. reason=${l.reason} action=${l.action}`
+                        + ` canReconnect=${l.canReconnect} at ${ts()}`);
                     cleanup();
                     break;
+                }
+                case 'refreshToken': {
+                    // The server refreshes the access token every ~5 minutes. Signaling-level resume
+                    // with it is a dead end for us (the server demands an ICE restart + DTLS
+                    // continuation werift can't do), so survival across the enforced 10-minute token
+                    // expiry is handled by LiveKitCameraStream pre-warming a whole new session.
+                    const claims = jwtClaims(msg.value);
+                    if (claims)
+                        dlog(`SS:LiveKit refreshToken claims sub=${claims.sub}`
+                            + ` nbf=${claims.nbf} exp=${claims.exp} ttl=${claims.exp - claims.nbf}s at ${ts()}`);
+                    break;
+                }
+                case 'streamStateUpdate':
+                    // The SFU pausing our subscribed track (congestion control / publisher pause)
+                    // stops video RTP entirely — the prime suspect for mid-stream dead windows.
+                    for (const s of msg.value.streamStates ?? [])
+                        dlog(`SS:LiveKit streamState ${s.trackSid}:`
+                            + ` ${s.state === StreamState.PAUSED ? 'PAUSED' : 'ACTIVE'} at ${ts()}`);
+                    break;
+                case 'update':
+                    // Participant updates carry per-track mute flags; a camera muting its video
+                    // track mid-session is another dead-window candidate.
+                    for (const p of msg.value.participants ?? []) {
+                        const tracks = (p.tracks ?? [])
+                            .map(t => `${t.sid}${t.muted ? ':muted' : ':live'}`)
+                            .join(' ');
+                        dlog(`SS:LiveKit participant ${p.identity} state=${p.state} tracks=[${tracks}] at ${ts()}`);
+                    }
+                    break;
                 default:
+                    if (msg.case && msg.case !== 'pong' && msg.case !== 'pongResp' && msg.case !== 'connectionQuality')
+                        dlog('SS:LiveKit signal:', msg.case, 'at', ts());
                     break;
             }
         }
@@ -620,7 +774,6 @@ async function startLiveKitViewer(details: LiveKitDetails, console: ConsoleLike,
     ws.on('message', (data: WebSocket.RawData) => {
         signalQueue = signalQueue.then(() => handleSignal(data));
     });
-
     ws.on('close', () => dlog('SS:LiveKit ws closed.'));
 
     // Wait for the subscriber peer connection to connect and deliver at least a video track.
@@ -741,7 +894,23 @@ async function startLiveKitViewer(details: LiveKitDetails, console: ConsoleLike,
         return micPublish;
     };
 
-    return { pc: pc!, videoTrack, audioTrack, close: cleanup, getKeyframe: () => keyframeCapturer.keyframe, ensureMicTrack, claimMic, writeMic };
+    return {
+        get videoCodec() { return videoTrack?.codec; },
+        get audioCodec() { return audioTrack?.codec; },
+        tokenExp: typeof joinClaims?.exp === 'number' ? joinClaims.exp : undefined,
+        isHealthy: () => !closed && pc?.connectionState !== 'failed' && pc?.connectionState !== 'closed',
+        onClosed: (cb: () => void) => {
+            if (closed)
+                cb();
+            else
+                closedCallbacks.push(cb);
+        },
+        close: cleanup,
+        getKeyframe: () => keyframeCapturer.keyframe,
+        ensureMicTrack,
+        claimMic,
+        writeMic,
+    };
 }
 
 /**
@@ -861,6 +1030,18 @@ export class LiveKitCameraStream {
     private viewerPromise?: Promise<LiveKitViewer>;
     private refcount = 0;
 
+    // Stable consumer-facing relays. Viewers (one per LiveKit session) push their received RTP
+    // into these via per-viewer sinks; the rebasers keep sequence numbers/timestamps continuous
+    // when the active session is swapped by a rollover, so consumers never renegotiate.
+    readonly videoRelay = new MediaStreamTrack({ kind: 'video' });
+    readonly audioRelay = new MediaStreamTrack({ kind: 'audio' });
+    private readonly videoRebaser = new RtpRebaser(90000);
+    private readonly audioRebaser = new RtpRebaser(48000);
+    private genCounter = 0;
+    private activeGen = 0;
+    private rolloverTimer?: NodeJS.Timeout;
+    private streamEndedCbs: (() => void)[] = [];
+
     constructor(
         private getDetails: () => Promise<LiveKitDetails>,
         private console: ConsoleLike,
@@ -873,9 +1054,108 @@ export class LiveKitCameraStream {
             this.console.log(...args);
     }
 
-    private viewerHealthy(viewer: LiveKitViewer): boolean {
-        const state = viewer.pc.connectionState;
-        return state !== 'failed' && state !== 'closed';
+    get videoCodec(): RTCRtpCodecParameters | undefined {
+        return this.viewer?.videoCodec;
+    }
+
+    get audioCodec(): RTCRtpCodecParameters | undefined {
+        return this.viewer?.audioCodec;
+    }
+
+    claimMic(token: object): boolean {
+        return this.viewer?.claimMic(token) ?? false;
+    }
+
+    writeMic(rtp: RtpPacket): void {
+        this.viewer?.writeMic(rtp);
+    }
+
+    async ensureMicTrack(): Promise<MediaStreamTrack> {
+        const viewer = await this.ensureViewer();
+        return viewer.ensureMicTrack();
+    }
+
+    /** Fired when the stream truly ends (active session died with no replacement). */
+    onStreamEnded(cb: () => void): void {
+        this.streamEndedCbs.push(cb);
+    }
+
+    private fireStreamEnded(): void {
+        for (const cb of this.streamEndedCbs.splice(0)) {
+            try { cb(); } catch { /* ignore */ }
+        }
+    }
+
+    /**
+     * Per-viewer RTP sinks. The video sink of a NEWER generation activates that generation on its
+     * first packet (the moment the pre-warmed replacement session delivers video); packets from
+     * older generations are dropped from then on. Audio strictly follows the active generation so
+     * the rebasers see clean source switches rather than interleaved sources.
+     */
+    private makeSinks(gen: number): ViewerSinks {
+        return {
+            video: rtp => {
+                if (gen < this.activeGen)
+                    return;
+                if (gen > this.activeGen) {
+                    this.activeGen = gen;
+                    this.dlog(`SS:LiveKit rollover: video source switched to session gen ${gen}`);
+                }
+                this.videoRelay.writeRtp(this.videoRebaser.rebase(gen, rtp));
+            },
+            audio: rtp => {
+                if (gen !== this.activeGen)
+                    return;
+                this.audioRelay.writeRtp(this.audioRebaser.rebase(gen, rtp));
+            },
+        };
+    }
+
+    /**
+     * SimpliSafe's LiveKit server enforces the join token's 10-minute expiry (media stops at exp,
+     * CONNECTION_TIMEOUT leave follows; signaling-level resume demands an ICE restart + DTLS
+     * continuation werift cannot do). So shortly before expiry, pre-warm a complete replacement
+     * session — a fresh live-view token joins as a distinct participant identity, so both sessions
+     * briefly coexist — and cut consumers over on its first video packet.
+     */
+    private scheduleRollover(viewer: LiveKitViewer): void {
+        if (this.rolloverTimer)
+            clearTimeout(this.rolloverTimer);
+        if (!viewer.tokenExp)
+            return;
+        const delay = viewer.tokenExp * 1000 - Date.now() - 45_000;
+        if (delay <= 0)
+            return;
+        this.rolloverTimer = setTimeout(() => {
+            this.rollover(viewer).catch(err =>
+                this.dlog('SS:LiveKit rollover failed; session rides to expiry and self-heals.', err));
+        }, delay);
+        this.dlog(`SS:LiveKit rollover scheduled in ${Math.round(delay / 1000)}s`);
+    }
+
+    private async rollover(oldViewer: LiveKitViewer): Promise<void> {
+        if (this.viewer !== oldViewer || this.refcount === 0)
+            return;
+        this.dlog('SS:LiveKit rollover: pre-warming replacement session before token expiry.');
+        const details = await this.getDetails();
+        const next = await startLiveKitViewer(details, this.console, this.debug, this.makeSinks(++this.genCounter));
+        if (this.viewer !== oldViewer || this.refcount === 0) {
+            next.close();
+            return;
+        }
+        this.viewer = next;
+        this.viewerPromise = Promise.resolve(next);
+        next.onClosed(() => {
+            if (this.viewer === next) {
+                this.viewer = undefined;
+                this.viewerPromise = undefined;
+                this.fireStreamEnded();
+            }
+        });
+        this.scheduleRollover(next);
+        // Let the replacement deliver its first video (which flips the active source), then drop
+        // the old session; closing it first would open a gap.
+        setTimeout(() => { try { oldViewer.close(); } catch { /* ignore */ } }, 2000);
     }
 
     /**
@@ -887,23 +1167,25 @@ export class LiveKitCameraStream {
     }
 
     private async ensureViewer(): Promise<LiveKitViewer> {
-        if (this.viewer && this.viewerHealthy(this.viewer))
+        if (this.viewer && this.viewer.isHealthy())
             return this.viewer;
 
         if (!this.viewerPromise) {
             this.viewerPromise = (async () => {
                 const details = await this.getDetails();
-                const viewer = await startLiveKitViewer(details, this.console, this.debug);
+                const viewer = await startLiveKitViewer(details, this.console, this.debug, this.makeSinks(++this.genCounter));
                 this.dlog('SS:LiveKit subscriber connected; bridging to Scrypted.',
-                    'video=', viewer.videoTrack?.codec?.mimeType ?? false,
-                    'audio=', viewer.audioTrack?.codec?.mimeType ?? false);
+                    'video=', viewer.videoCodec?.mimeType ?? false,
+                    'audio=', viewer.audioCodec?.mimeType ?? false);
                 this.viewer = viewer;
-                viewer.pc.connectionStateChange.subscribe(state => {
-                    if ((state === 'failed' || state === 'closed') && this.viewer === viewer) {
+                viewer.onClosed(() => {
+                    if (this.viewer === viewer) {
                         this.viewer = undefined;
                         this.viewerPromise = undefined;
+                        this.fireStreamEnded();
                     }
                 });
+                this.scheduleRollover(viewer);
                 return viewer;
             })();
             this.viewerPromise.catch(() => { this.viewerPromise = undefined; });
@@ -912,10 +1194,10 @@ export class LiveKitCameraStream {
     }
 
     async startSession(session: RTCSignalingSession): Promise<RTCSessionControl> {
-        const viewer = await this.ensureViewer();
+        await this.ensureViewer();
         this.refcount++;
         try {
-            return await bridgeToScryptedSession(session, viewer, this.console, () => this.release());
+            return await bridgeToScryptedSession(session, this, this.console, () => this.release());
         }
         catch (err) {
             this.release();
@@ -952,6 +1234,8 @@ export class LiveKitCameraStream {
     private release(): void {
         this.refcount = Math.max(0, this.refcount - 1);
         if (this.refcount === 0) {
+            if (this.rolloverTimer)
+                clearTimeout(this.rolloverTimer);
             this.viewer?.close();
             this.viewer = undefined;
             this.viewerPromise = undefined;
@@ -961,15 +1245,15 @@ export class LiveKitCameraStream {
 
 async function bridgeToScryptedSession(
     session: RTCSignalingSession,
-    viewer: LiveKitViewer,
+    stream: LiveKitCameraStream,
     console: ConsoleLike,
     onEnd: () => void,
 ): Promise<RTCSessionControl> {
 
     // Match the consumer peer connection's codecs to what LiveKit negotiated so RTP can be
     // forwarded without transcoding (payload types line up).
-    const videoCodec = viewer.videoTrack?.codec;
-    const audioCodec = viewer.audioTrack?.codec;
+    const videoCodec = stream.videoCodec;
+    const audioCodec = stream.audioCodec;
     const codecs: { video?: RTCRtpCodecParameters[]; audio?: RTCRtpCodecParameters[] } = {};
     if (videoCodec)
         codecs.video = [videoCodec];
@@ -981,20 +1265,20 @@ async function bridgeToScryptedSession(
         codecs,
     });
 
-    // Outbound video, fed by forwarding RTP from the LiveKit track.
+    // Outbound video, fed from the stream's stable relay (survives session rollovers).
     const videoOut = new MediaStreamTrack({ kind: 'video' });
     consumerPc.addTransceiver(videoOut, { direction: 'sendonly' });
-    viewer.videoTrack?.onReceiveRtp.subscribe(rtp => videoOut.writeRtp(rtp));
+    stream.videoRelay.onReceiveRtp.subscribe(rtp => videoOut.writeRtp(rtp));
 
     // Audio is bidirectional. We send the camera's audio to the consumer AND accept talk-back (the
     // viewer's microphone) on the same transceiver: Scrypted's WebRTC plugin implements HomeKit
     // two-way audio by pushing the mic audio back over THIS peer connection (it requests sendrecv),
     // not by calling the device's Intercom. Any inbound audio is forwarded up to the LiveKit
     // publisher so it reaches the camera.
-    if (viewer.audioTrack) {
+    if (audioCodec) {
         const audioOut = new MediaStreamTrack({ kind: 'audio' });
         consumerPc.addTransceiver(audioOut, { direction: 'sendrecv' });
-        viewer.audioTrack.onReceiveRtp.subscribe(rtp => audioOut.writeRtp(rtp));
+        stream.audioRelay.onReceiveRtp.subscribe(rtp => audioOut.writeRtp(rtp));
     }
     else {
         consumerPc.addTransceiver('audio', { direction: 'recvonly' });
@@ -1013,18 +1297,18 @@ async function bridgeToScryptedSession(
             return;
         track.onReceiveRtp.subscribe(rtp => {
             // Take (or keep) exclusive ownership of the shared mic; bail if another session is talking.
-            if (!viewer.claimMic(micToken))
+            if (!stream.claimMic(micToken))
                 return;
             if (!micStarting) {
                 micStarting = true;
-                viewer.ensureMicTrack()
+                stream.ensureMicTrack()
                     .then(() => { micStarted = true; })
                     .catch(err => console.warn('SS:LiveKit talk-back publish failed.', err));
             }
             if (!micStarted)
                 return;
             // Forward into the shared mic track with monotonic sequence/timestamp rewriting.
-            viewer.writeMic(rtp);
+            stream.writeMic(rtp);
         });
     });
 
@@ -1058,9 +1342,10 @@ async function bridgeToScryptedSession(
         if (state === 'failed' || state === 'closed')
             control.endSession().catch(() => { /* ignore */ });
     });
-    viewer.pc.connectionStateChange.subscribe(state => {
-        if (state === 'failed' || state === 'closed')
-            control.endSession().catch(() => { /* ignore */ });
+    // End the consumer session only when the stream truly ends (active session died with no
+    // replacement) — NOT on session rollovers, which consumers ride through via the relays.
+    stream.onStreamEnded(() => {
+        control.endSession().catch(() => { /* ignore */ });
     });
 
     return control;

--- a/src/livekit.ts
+++ b/src/livekit.ts
@@ -322,6 +322,8 @@ interface LiveKitViewer {
      * published only once and reused across all consumer sessions.
      */
     ensureMicTrack: () => Promise<MediaStreamTrack>;
+    /** The published mic track, if ensureMicTrack has completed on this viewer. */
+    getMicTrack: () => MediaStreamTrack | undefined;
     /**
      * Request exclusive use of the shared talk-back track for the calling session (identified by a
      * stable token). Returns true if this session owns the mic and may write RTP; false if another
@@ -976,6 +978,7 @@ async function startLiveKitViewer(details: LiveKitDetails, console: ConsoleLike,
         close: cleanup,
         getKeyframe: () => keyframeCapturer.keyframe,
         ensureMicTrack,
+        getMicTrack: () => micTrackRef,
         claimMic,
         writeMic,
         isMicActive: () => !!micOwner,
@@ -1250,6 +1253,13 @@ export class LiveKitCameraStream {
             }
         });
         this.scheduleRollover(next);
+        // A device-level intercom may be mid-talk (rollover forced at the token drop-dead point);
+        // re-publish the shared mic on the replacement so the intercom's per-packet track lookup
+        // resumes flowing instead of writing into the old viewer's dead track.
+        if (this.micSinkHolds > 0) {
+            next.ensureMicTrack().catch(err =>
+                this.dlog('SS:LiveKit mic re-publish after rollover failed.', err));
+        }
         // Let the replacement deliver its first video (which flips the active source), then drop
         // the old session; closing it first would open a gap.
         setTimeout(() => { try { oldViewer.close(); } catch { /* ignore */ } }, 2000);
@@ -1314,10 +1324,11 @@ export class LiveKitCameraStream {
     /**
      * Acquire the shared talk-back sink for the device-level Intercom path (used by non-WebRTC
      * consumers). Ensures a connection exists (so talk-back works even if nothing is actively
-     * viewing) and holds a refcount for the duration. Returns the shared mic track to write RTP
-     * into, plus a release function that drops the refcount.
+     * viewing) and holds a refcount for the duration. Returns an accessor for the shared mic
+     * track — resolved per call, because a forced mid-talk rollover swaps the viewer and the
+     * track published at acquire time goes dead — plus a release function that drops the refcount.
      */
-    async acquireMicSink(): Promise<{ track: MediaStreamTrack; release: () => void }> {
+    async acquireMicSink(): Promise<{ getTrack: () => MediaStreamTrack | undefined; release: () => void }> {
         const viewer = await this.ensureViewer();
         this.refcount++;
         this.micSinkHolds++;
@@ -1330,8 +1341,8 @@ export class LiveKitCameraStream {
             this.release();
         };
         try {
-            const track = await viewer.ensureMicTrack();
-            return { track, release };
+            await viewer.ensureMicTrack();
+            return { getTrack: () => this.viewer?.getMicTrack(), release };
         }
         catch (err) {
             release();

--- a/src/livekit.ts
+++ b/src/livekit.ts
@@ -19,6 +19,7 @@
 import WebSocket from 'ws';
 import {
     MediaStreamTrack,
+    RtpPacket,
     RTCIceCandidate,
     RTCPeerConnection,
     RTCRtpCodecParameters,
@@ -50,11 +51,34 @@ const SUBSCRIBE_AUDIO_CODECS = [
         payloadType: 111,
     }),
 ];
+// Talk-back (microphone) is published with RED (RFC 2198 redundant Opus) as the primary codec,
+// matching exactly what the SimpliSafe app publishes (track name "microphone", mimeType audio/red).
+// The camera only plays audio published this way. werift auto-fills the red codec's parameters to
+// `${payloadType+1}/${payloadType+1}`, so opus must sit at the red payloadType + 1 (110 -> 111), and
+// werift's sender then RED-wraps the forwarded Opus payloads automatically.
+const PUBLISH_AUDIO_CODECS = [
+    new RTCRtpCodecParameters({
+        mimeType: 'audio/red',
+        clockRate: 48000,
+        channels: 2,
+        payloadType: 110,
+    }),
+    new RTCRtpCodecParameters({
+        mimeType: 'audio/opus',
+        clockRate: 48000,
+        channels: 2,
+        payloadType: 111,
+    }),
+];
 import {
+    AddTrackRequest,
+    MuteTrackRequest,
     SessionDescription,
     SignalRequest,
     SignalResponse,
     SignalTarget,
+    TrackSource,
+    TrackType,
     TrickleRequest,
 } from '@livekit/protocol';
 import type {
@@ -109,6 +133,24 @@ interface LiveKitViewer {
     videoTrack?: MediaStreamTrack;
     audioTrack?: MediaStreamTrack;
     close: () => void;
+    /**
+     * Lazily publish a single shared talk-back (microphone) track to LiveKit over this same
+     * participant connection and return it. Callers write RTP into the returned track; it is
+     * published only once and reused across all consumer sessions.
+     */
+    ensureMicTrack: () => Promise<MediaStreamTrack>;
+    /**
+     * Request exclusive use of the shared talk-back track for the calling session (identified by a
+     * stable token). Returns true if this session owns the mic and may write RTP; false if another
+     * session is currently talking. Unmutes on claim and re-mutes after the talker goes idle,
+     * mirroring how the SimpliSafe app toggles mute per talk so the camera re-triggers playback.
+     */
+    claimMic: (token: object) => boolean;
+    /**
+     * Write a talk-back packet into the shared mic track, rewriting its sequence/timestamp to our own
+     * monotonic counters so the stream stays continuous across consumer-session (source) switches.
+     */
+    writeMic: (rtp: RtpPacket) => void;
 }
 
 /**
@@ -137,11 +179,65 @@ async function startLiveKitViewer(details: LiveKitDetails, console: ConsoleLike,
     let remoteDescriptionSet = false;
     const pendingCandidates: RTCIceCandidate[] = [];
 
+    // Publisher (outbound) peer connection state, created lazily when the first mic track is
+    // published. LiveKit uses a separate publisher PC on the SAME signaling websocket/participant.
+    let joinIceServers: any[] = [];
+    let publisherPc: RTCPeerConnection | undefined;
+    let publisherRemoteDescriptionSet = false;
+    let publisherMicSender: any;
+    const pendingPublisherCandidates: RTCIceCandidate[] = [];
+
+    // Mic mute state. The SimpliSafe app toggles its published microphone track muted<->unmuted per
+    // talk; the camera keys its speaker off the unmute (mute->unmute) transition. We keep one
+    // persistent published track and mute it after talk-back audio stops so the next talk unmutes
+    // afresh — otherwise a permanently-unmuted track only triggers the camera the first time.
+    //
+    // There is ONE shared published mic track but potentially several consumer sessions (multiple
+    // HomeKit devices). Only one may feed the track at a time: interleaving RTP from two sessions
+    // (different SSRCs/timestamps) into the single sender corrupts the RED/sequence state and breaks
+    // talk-back for everyone until the connection is torn down. `claimMic(token)` grants exclusive
+    // ownership to the first talker; others are refused until the owner goes idle (inactivity).
+    let micSid: string | undefined;
+    let micMuted = false;
+    let micOwner: object | undefined;
+    let micMuteTimer: NodeJS.Timeout | undefined;
+    const sendMute = (muted: boolean) => {
+        if (!micSid)
+            return;
+        send({ case: 'mute', value: new MuteTrackRequest({ sid: micSid, muted }) });
+        dlog('SS:LiveKit mic', muted ? 'muted (talk stop)' : 'unmuted (talk start)', micSid);
+    };
+    // Called on each inbound talk-back packet with the calling session's token. Returns true only if
+    // this session owns the mic (and may write RTP). Unmutes on claim and arms an inactivity timer
+    // that releases ownership + re-mutes shortly after audio stops.
+    const claimMic = (token: object): boolean => {
+        if (micOwner && micOwner !== token)
+            return false;
+        if (!micOwner) {
+            micOwner = token;
+            if (micMuted) {
+                micMuted = false;
+                sendMute(false);
+            }
+        }
+        if (micMuteTimer)
+            clearTimeout(micMuteTimer);
+        micMuteTimer = setTimeout(() => {
+            micOwner = undefined;
+            micMuted = true;
+            sendMute(true);
+        }, 800);
+        return true;
+    };
+
     const cleanup = () => {
         if (pingTimer)
             clearInterval(pingTimer);
+        if (micMuteTimer)
+            clearTimeout(micMuteTimer);
         try { ws.close(); } catch { /* ignore */ }
         try { pc?.close(); } catch { /* ignore */ }
+        try { publisherPc?.close(); } catch { /* ignore */ }
     };
 
     const send = (message: SignalRequest['message']) => {
@@ -199,6 +295,7 @@ async function startLiveKitViewer(details: LiveKitDetails, console: ConsoleLike,
                     const join = msg.value;
                     dlog('SS:LiveKit join subscriberPrimary=', join.subscriberPrimary,
                         'iceServers=', join.iceServers?.length, 'pingInterval=', join.pingInterval);
+                    joinIceServers = join.iceServers as any[];
                     setupPeerConnection(join.iceServers as any[]);
                     const intervalMs = (join.pingInterval || 30) * 1000;
                     pingTimer = setInterval(() => send({ case: 'ping', value: BigInt(Date.now()) }), intervalMs);
@@ -227,9 +324,30 @@ async function startLiveKitViewer(details: LiveKitDetails, console: ConsoleLike,
                     });
                     break;
                 }
-                case 'trickle': {
-                    if (!pc)
+                case 'answer': {
+                    // The server answers the offer we sent on the PUBLISHER peer connection when
+                    // publishing the mic track. (The subscriber flow is the reverse: server offers.)
+                    if (!publisherPc) {
+                        console.warn('SS:LiveKit received answer with no publisher PC; ignoring.');
                         break;
+                    }
+                    const answer = msg.value;
+                    await publisherPc.setRemoteDescription({ type: 'answer', sdp: answer.sdp });
+                    publisherRemoteDescriptionSet = true;
+                    for (const candidate of pendingPublisherCandidates.splice(0))
+                        await publisherPc.addIceCandidate(candidate).catch(() => { /* ignore */ });
+                    // werift derives the RED block payload type from the negotiated red fmtp, but
+                    // LiveKit's answer leaves it empty -> redRedundantPayloadType=0 (falsy) -> the
+                    // sender skips RED wrapping and ships raw Opus mislabelled as RED, which the camera
+                    // can't decode. Force it to the Opus PT so werift actually builds RED packets.
+                    if (publisherMicSender && !publisherMicSender.redRedundantPayloadType) {
+                        publisherMicSender.redRedundantPayloadType = PUBLISH_AUDIO_CODECS[1].payloadType;
+                        dlog('SS:LiveKit forced publisher RED redundant PT=', publisherMicSender.redRedundantPayloadType);
+                    }
+                    dlog('SS:LiveKit publisher answer applied.');
+                    break;
+                }
+                case 'trickle': {
                     const init = JSON.parse(msg.value.candidateInit);
                     if (!init?.candidate)
                         break;
@@ -238,12 +356,29 @@ async function startLiveKitViewer(details: LiveKitDetails, console: ConsoleLike,
                         sdpMid: init.sdpMid,
                         sdpMLineIndex: init.sdpMLineIndex,
                     });
+                    if (msg.value.target === SignalTarget.PUBLISHER) {
+                        if (!publisherPc)
+                            break;
+                        if (publisherRemoteDescriptionSet)
+                            await publisherPc.addIceCandidate(candidate).catch(() => { /* ignore */ });
+                        else
+                            pendingPublisherCandidates.push(candidate);
+                        break;
+                    }
+                    if (!pc)
+                        break;
                     if (remoteDescriptionSet)
                         await pc.addIceCandidate(candidate).catch(() => { /* ignore */ });
                     else
                         pendingCandidates.push(candidate);
                     break;
                 }
+                case 'trackPublished':
+                    dlog('SS:LiveKit track published:', msg.value.cid, msg.value.track?.sid, msg.value.track?.type);
+                    // Remember the mic track sid so we can mute/unmute it per talk session.
+                    if (msg.value.track?.type === TrackType.AUDIO && msg.value.track?.sid)
+                        micSid = msg.value.track.sid;
+                    break;
                 case 'leave':
                     dlog('SS:LiveKit server requested leave.');
                     cleanup();
@@ -300,7 +435,92 @@ async function startLiveKitViewer(details: LiveKitDetails, console: ConsoleLike,
         }, 100);
     });
 
-    return { pc: pc!, videoTrack, audioTrack, close: cleanup };
+    // A single, persistent talk-back (microphone) track is published to LiveKit at most once per
+    // connection and shared by every consumer session. Publishing per-session would add a new
+    // transceiver and renegotiate the shared publisher each time, which corrupts it after the first
+    // session (talk-back "works once then stops").
+    //
+    // Every consumer session's talk-back RTP is written into this one shared sender. Each HomeKit
+    // talk session has its own SSRC/sequence/timestamp bases, and werift's sender passes the input
+    // sequence/timestamp through (only offsetting the SSRC), so switching sources would make the
+    // sequence jump backwards and the camera would discard the packets as stale. `writeMic` rewrites
+    // every packet's sequence/timestamp to our own monotonic counters so the stream stays continuous
+    // across source switches, regardless of which session is talking.
+    let micPublish: Promise<MediaStreamTrack> | undefined;
+    let micTrackRef: MediaStreamTrack | undefined;
+    let micSeq = Math.floor(Math.random() * 0xffff);
+    let micTs = Math.floor(Math.random() * 0xffffffff);
+    const writeMic = (rtp: RtpPacket): void => {
+        if (!micTrackRef)
+            return;
+        rtp.header.sequenceNumber = micSeq;
+        micSeq = (micSeq + 1) & 0xffff;
+        rtp.header.timestamp = micTs;
+        micTs = (micTs + 960) >>> 0; // 20ms @ 48kHz Opus
+        micTrackRef.writeRtp(rtp);
+    };
+    const ensureMicTrack = (): Promise<MediaStreamTrack> => {
+        if (micPublish)
+            return micPublish;
+        micPublish = (async () => {
+            if (!publisherPc) {
+                publisherPc = new RTCPeerConnection({
+                    iceServers: normalizeIceServers(joinIceServers),
+                    bundlePolicy: 'max-bundle',
+                    codecs: { audio: PUBLISH_AUDIO_CODECS },
+                });
+                publisherPc.onIceCandidate.subscribe(candidate => {
+                    if (!candidate?.candidate)
+                        return;
+                    send({
+                        case: 'trickle',
+                        value: new TrickleRequest({
+                            candidateInit: JSON.stringify(candidate.toJSON()),
+                            target: SignalTarget.PUBLISHER,
+                        }),
+                    });
+                });
+                publisherPc.connectionStateChange.subscribe(state =>
+                    dlog('SS:LiveKit publisher connection state:', state));
+            }
+
+            const track = new MediaStreamTrack({ kind: 'audio', id: `mic-${Date.now()}` });
+            micTrackRef = track;
+            const micTransceiver = publisherPc.addTransceiver(track, { direction: 'sendonly' });
+            // The 'answer' handler force-enables RED wrapping on this sender once negotiation settles
+            // (werift otherwise leaves redRedundantPayloadType=0 and sends raw Opus mislabelled as RED).
+            publisherMicSender = micTransceiver.sender;
+
+            // Announce the track to LiveKit, then negotiate: we (the client) offer on the PUBLISHER
+            // target and the server answers (handled in the 'answer' case above).
+            const cid = track.id!;
+            send({
+                case: 'addTrack',
+                value: new AddTrackRequest({
+                    cid,
+                    // Match the SimpliSafe app's talk-back track exactly (name "microphone"); the
+                    // camera keys its speaker playback off this convention.
+                    name: 'microphone',
+                    type: TrackType.AUDIO,
+                    source: TrackSource.MICROPHONE,
+                }),
+            });
+
+            const offer = await publisherPc.createOffer();
+            await publisherPc.setLocalDescription(offer);
+            send({
+                case: 'offer',
+                value: new SessionDescription({ type: 'offer', sdp: offer.sdp }),
+            });
+            dlog('SS:LiveKit publishing mic track cid=', cid);
+            return track;
+        })();
+        // Allow a retry on failure (e.g. transient publisher negotiation error).
+        micPublish.catch(() => { micPublish = undefined; });
+        return micPublish;
+    };
+
+    return { pc: pc!, videoTrack, audioTrack, close: cleanup, ensureMicTrack, claimMic, writeMic };
 }
 
 /**
@@ -474,6 +694,32 @@ export class LiveKitCameraStream {
         }
     }
 
+    /**
+     * Acquire the shared talk-back sink for the device-level Intercom path (used by non-WebRTC
+     * consumers). Ensures a connection exists (so talk-back works even if nothing is actively
+     * viewing) and holds a refcount for the duration. Returns the shared mic track to write RTP
+     * into, plus a release function that drops the refcount.
+     */
+    async acquireMicSink(): Promise<{ track: MediaStreamTrack; release: () => void }> {
+        const viewer = await this.ensureViewer();
+        this.refcount++;
+        let released = false;
+        const release = () => {
+            if (released)
+                return;
+            released = true;
+            this.release();
+        };
+        try {
+            const track = await viewer.ensureMicTrack();
+            return { track, release };
+        }
+        catch (err) {
+            release();
+            throw err;
+        }
+    }
+
     private release(): void {
         this.refcount = Math.max(0, this.refcount - 1);
         if (this.refcount === 0) {
@@ -506,25 +752,60 @@ async function bridgeToScryptedSession(
         codecs,
     });
 
-    // Outbound tracks fed by forwarding RTP from the LiveKit tracks.
+    // Outbound video, fed by forwarding RTP from the LiveKit track.
     const videoOut = new MediaStreamTrack({ kind: 'video' });
     consumerPc.addTransceiver(videoOut, { direction: 'sendonly' });
     viewer.videoTrack?.onReceiveRtp.subscribe(rtp => videoOut.writeRtp(rtp));
 
-    let audioOut: MediaStreamTrack | undefined;
+    // Audio is bidirectional. We send the camera's audio to the consumer AND accept talk-back (the
+    // viewer's microphone) on the same transceiver: Scrypted's WebRTC plugin implements HomeKit
+    // two-way audio by pushing the mic audio back over THIS peer connection (it requests sendrecv),
+    // not by calling the device's Intercom. Any inbound audio is forwarded up to the LiveKit
+    // publisher so it reaches the camera.
     if (viewer.audioTrack) {
-        audioOut = new MediaStreamTrack({ kind: 'audio' });
-        consumerPc.addTransceiver(audioOut, { direction: 'sendonly' });
-        viewer.audioTrack.onReceiveRtp.subscribe(rtp => audioOut!.writeRtp(rtp));
+        const audioOut = new MediaStreamTrack({ kind: 'audio' });
+        consumerPc.addTransceiver(audioOut, { direction: 'sendrecv' });
+        viewer.audioTrack.onReceiveRtp.subscribe(rtp => audioOut.writeRtp(rtp));
     }
+    else {
+        consumerPc.addTransceiver('audio', { direction: 'recvonly' });
+    }
+
+    // Forward inbound talk-back audio into the shared LiveKit mic track. The track is published once
+    // (lazily, on first audio) and reused across every session, so re-publishing/renegotiation never
+    // happens — that was corrupting the shared publisher after the first talk-back. Only the session
+    // that currently owns the mic (claimMic) writes RTP: mixing two sessions into the one sender
+    // corrupts it and breaks talk-back for everyone.
+    let micStarted = false;
+    let micStarting = false;
+    const micToken = {};
+    consumerPc.onTrack.subscribe(track => {
+        if (track.kind !== 'audio')
+            return;
+        track.onReceiveRtp.subscribe(rtp => {
+            // Take (or keep) exclusive ownership of the shared mic; bail if another session is talking.
+            if (!viewer.claimMic(micToken))
+                return;
+            if (!micStarting) {
+                micStarting = true;
+                viewer.ensureMicTrack()
+                    .then(() => { micStarted = true; })
+                    .catch(err => console.warn('SS:LiveKit talk-back publish failed.', err));
+            }
+            if (!micStarted)
+                return;
+            // Forward into the shared mic track with monotonic sequence/timestamp rewriting.
+            viewer.writeMic(rtp);
+        });
+    });
 
     const weriftSession = new WeriftSignalingSession(console, consumerPc);
     const consumerSetup: Partial<RTCAVSignalingSetup> = {
-        audio: { direction: 'sendonly' },
+        audio: { direction: 'sendrecv' },
         video: { direction: 'sendonly' },
     };
     const sessionSetup: Partial<RTCAVSignalingSetup> = {
-        audio: { direction: 'recvonly' },
+        audio: { direction: 'sendrecv' },
         video: { direction: 'recvonly' },
     };
 
@@ -539,7 +820,8 @@ async function bridgeToScryptedSession(
     const control = new SimplisafeRTCSessionControl(() => {
         try { consumerPc.close(); } catch { /* ignore */ }
         // Release this consumer's hold on the shared LiveKit connection; the streamer tears the
-        // upstream down only when the last consumer leaves.
+        // upstream down only when the last consumer leaves. The shared mic track is not torn down
+        // per session — it lives with the viewer and is closed when the last consumer leaves.
         onEnd();
     });
 

--- a/src/livekit.ts
+++ b/src/livekit.ts
@@ -1,0 +1,589 @@
+/**
+ * LiveKit live streaming for newer SimpliSafe cameras.
+ *
+ * Despite reporting `providers.webrtc === 'kvs'`, newer SimpliSafe cameras actually stream over
+ * LiveKit (not Amazon KVS). The `/v2/cameras/{uuid}/{location}/live-view` endpoint returns:
+ *   { liveKitDetails: { liveKitURL: "wss://livestream.services.simplisafe.com:7880",
+ *                       userToken: "<LiveKit access-token JWT>" }, cameraStatus: "online" }
+ *
+ * We connect to LiveKit as a subscriber (auto_subscribe), let the server offer its subscriber
+ * peer connection, answer it with werift, and receive the camera's encoded audio/video RTP tracks.
+ * Those tracks are then forwarded (no transcoding) into a second werift peer connection that is
+ * negotiated with the Scrypted consumer `RTCSignalingSession`. The WeriftSignalingSession /
+ * connectRTCSignalingClients helpers are adapted from @scrypted/webrtc.
+ *
+ * Signaling protocol reference: livekit/client-sdk-js (SignalClient/RTCEngine). Messages are
+ * @livekit/protocol SignalRequest/SignalResponse protobufs sent as binary websocket frames.
+ */
+
+import WebSocket from 'ws';
+import {
+    MediaStreamTrack,
+    RTCIceCandidate,
+    RTCPeerConnection,
+    RTCRtpCodecParameters,
+} from '@koush/werift';
+
+// SimpliSafe's LiveKit cameras publish multiple video codecs (VP8/VP9/H264/AV1/H265). werift
+// defaults to VP8, but Scrypted's WebRTC->RTSP path only accepts H264. Constraining the
+// subscriber to H264 makes the camera send H264 directly, avoiding any transcode. These params
+// mirror @scrypted/webrtc's requiredVideoCodec / Opus so the downstream negotiation lines up.
+const SUBSCRIBE_VIDEO_CODECS = [
+    new RTCRtpCodecParameters({
+        mimeType: 'video/H264',
+        clockRate: 90000,
+        rtcpFeedback: [
+            { type: 'transport-cc' },
+            { type: 'ccm', parameter: 'fir' },
+            { type: 'nack' },
+            { type: 'nack', parameter: 'pli' },
+            { type: 'goog-remb' },
+        ],
+        parameters: 'level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=42e01f',
+    }),
+];
+const SUBSCRIBE_AUDIO_CODECS = [
+    new RTCRtpCodecParameters({
+        mimeType: 'audio/opus',
+        clockRate: 48000,
+        channels: 2,
+        payloadType: 111,
+    }),
+];
+import {
+    SessionDescription,
+    SignalRequest,
+    SignalResponse,
+    SignalTarget,
+    TrickleRequest,
+} from '@livekit/protocol';
+import type {
+    RTCAVSignalingSetup,
+    RTCSessionControl,
+    RTCSignalingOptions,
+    RTCSignalingSendIceCandidate,
+    RTCSignalingSession,
+} from '@scrypted/sdk';
+
+export interface LiveKitDetails {
+    liveKitURL: string;
+    userToken: string;
+}
+
+export interface LiveViewResponse {
+    liveKitDetails?: LiveKitDetails;
+    cameraStatus?: string;
+}
+
+type ConsoleLike = Pick<Console, 'log' | 'warn' | 'error'>;
+
+// Protocol/version advertised to the LiveKit server, mirroring livekit-client.
+const LK_PROTOCOL = 15;
+const LK_VERSION = '2.20.0';
+
+/**
+ * Flatten LiveKit ICE servers (protobuf ICEServer with a `urls` array) into werift's expected
+ * shape (one entry per url string).
+ */
+function normalizeIceServers(iceServers: any[] | undefined): any[] {
+    if (!Array.isArray(iceServers))
+        return [];
+    const ret: any[] = [];
+    for (const ice of iceServers) {
+        const urls = ice?.urls ?? ice?.url;
+        const credential = ice?.credential ?? ice?.password;
+        const username = ice?.username;
+        if (Array.isArray(urls)) {
+            for (const url of urls)
+                ret.push({ urls: url, username, credential });
+        }
+        else if (typeof urls === 'string') {
+            ret.push({ urls, username, credential });
+        }
+    }
+    return ret;
+}
+
+interface LiveKitViewer {
+    pc: RTCPeerConnection;
+    videoTrack?: MediaStreamTrack;
+    audioTrack?: MediaStreamTrack;
+    close: () => void;
+}
+
+/**
+ * Connect to LiveKit as a subscriber and return the negotiated peer connection plus the received
+ * media tracks.
+ */
+async function startLiveKitViewer(details: LiveKitDetails, console: ConsoleLike, debug: () => boolean): Promise<LiveKitViewer> {
+    const dlog = (...args: any[]) => { if (debug()) console.log(...args); };
+    const base = details.liveKitURL.replace(/\/$/, '');
+    const params = new URLSearchParams({
+        access_token: details.userToken,
+        auto_subscribe: '1',
+        sdk: 'js',
+        version: LK_VERSION,
+        protocol: String(LK_PROTOCOL),
+    });
+    const url = `${base}/rtc?${params.toString()}`;
+
+    dlog('SS:LiveKit connecting', base);
+    const ws = new WebSocket(url);
+
+    let pc: RTCPeerConnection | undefined;
+    let videoTrack: MediaStreamTrack | undefined;
+    let audioTrack: MediaStreamTrack | undefined;
+    let pingTimer: NodeJS.Timeout | undefined;
+    let remoteDescriptionSet = false;
+    const pendingCandidates: RTCIceCandidate[] = [];
+
+    const cleanup = () => {
+        if (pingTimer)
+            clearInterval(pingTimer);
+        try { ws.close(); } catch { /* ignore */ }
+        try { pc?.close(); } catch { /* ignore */ }
+    };
+
+    const send = (message: SignalRequest['message']) => {
+        if (ws.readyState !== WebSocket.OPEN)
+            return;
+        ws.send(new SignalRequest({ message }).toBinary());
+    };
+
+    const setupPeerConnection = (iceServers: any[]) => {
+        pc = new RTCPeerConnection({
+            iceServers: normalizeIceServers(iceServers),
+            bundlePolicy: 'max-bundle',
+            codecs: {
+                video: SUBSCRIBE_VIDEO_CODECS,
+                audio: SUBSCRIBE_AUDIO_CODECS,
+            },
+        });
+
+        pc.onIceCandidate.subscribe(candidate => {
+            if (!candidate?.candidate)
+                return;
+            send({
+                case: 'trickle',
+                value: new TrickleRequest({
+                    candidateInit: JSON.stringify(candidate.toJSON()),
+                    target: SignalTarget.SUBSCRIBER,
+                }),
+            });
+        });
+
+        pc.onTrack.subscribe(track => {
+            if (track.kind === 'video')
+                videoTrack = track;
+            else if (track.kind === 'audio')
+                audioTrack = track;
+        });
+    };
+
+    await new Promise<void>((resolve, reject) => {
+        const timeout = setTimeout(() => reject(new Error('LiveKit signaling websocket open timed out.')), 15000);
+        ws.on('open', () => { clearTimeout(timeout); dlog('SS:LiveKit ws open'); resolve(); });
+        ws.on('error', err => { clearTimeout(timeout); reject(err); });
+    });
+
+    const handleSignal = async (data: WebSocket.RawData) => {
+        try {
+            const bytes = data instanceof Buffer ? new Uint8Array(data)
+                : data instanceof ArrayBuffer ? new Uint8Array(data)
+                : new Uint8Array(data as any);
+            const resp = SignalResponse.fromBinary(bytes);
+            const msg = resp.message;
+
+            switch (msg.case) {
+                case 'join': {
+                    const join = msg.value;
+                    dlog('SS:LiveKit join subscriberPrimary=', join.subscriberPrimary,
+                        'iceServers=', join.iceServers?.length, 'pingInterval=', join.pingInterval);
+                    setupPeerConnection(join.iceServers as any[]);
+                    const intervalMs = (join.pingInterval || 30) * 1000;
+                    pingTimer = setInterval(() => send({ case: 'ping', value: BigInt(Date.now()) }), intervalMs);
+                    break;
+                }
+                case 'offer': {
+                    if (!pc) {
+                        console.warn('SS:LiveKit received offer before join; ignoring.');
+                        break;
+                    }
+                    const offer = msg.value;
+                    // Log the camera's offered H264 profiles so we can align werift's codec if the
+                    // negotiation fails to match.
+                    const h264 = (offer.sdp.match(/a=(rtpmap|fmtp):.*(H264|h264).*/g) || []).join(' | ');
+                    if (h264)
+                        dlog('SS:LiveKit server H264 offer:', h264);
+                    await pc.setRemoteDescription({ type: 'offer', sdp: offer.sdp });
+                    remoteDescriptionSet = true;
+                    for (const candidate of pendingCandidates.splice(0))
+                        await pc.addIceCandidate(candidate).catch(() => { /* ignore */ });
+                    const answer = await pc.createAnswer();
+                    await pc.setLocalDescription(answer);
+                    send({
+                        case: 'answer',
+                        value: new SessionDescription({ type: 'answer', sdp: answer.sdp, id: offer.id }),
+                    });
+                    break;
+                }
+                case 'trickle': {
+                    if (!pc)
+                        break;
+                    const init = JSON.parse(msg.value.candidateInit);
+                    if (!init?.candidate)
+                        break;
+                    const candidate = new RTCIceCandidate({
+                        candidate: init.candidate,
+                        sdpMid: init.sdpMid,
+                        sdpMLineIndex: init.sdpMLineIndex,
+                    });
+                    if (remoteDescriptionSet)
+                        await pc.addIceCandidate(candidate).catch(() => { /* ignore */ });
+                    else
+                        pendingCandidates.push(candidate);
+                    break;
+                }
+                case 'leave':
+                    dlog('SS:LiveKit server requested leave.');
+                    cleanup();
+                    break;
+                default:
+                    break;
+            }
+        }
+        catch (err) {
+            console.warn('Failed to handle LiveKit signaling message.', err);
+        }
+    };
+
+    // Serialize signaling: LiveKit renegotiates by sending several offers (audio first, then
+    // video). Processing them concurrently corrupts werift's signaling state and can drop the
+    // video offer, so handle one message at a time.
+    let signalQueue: Promise<void> = Promise.resolve();
+    ws.on('message', (data: WebSocket.RawData) => {
+        signalQueue = signalQueue.then(() => handleSignal(data));
+    });
+
+    ws.on('close', () => dlog('SS:LiveKit ws closed.'));
+
+    // Wait for the subscriber peer connection to connect and deliver at least a video track.
+    await new Promise<void>((resolve, reject) => {
+        const timeout = setTimeout(() => reject(new Error('LiveKit subscriber connection timed out.')), 30000);
+        let settled = false;
+        const finish = (err?: Error) => {
+            if (settled)
+                return;
+            settled = true;
+            clearTimeout(timeout);
+            err ? reject(err) : resolve();
+        };
+        const check = () => {
+            if (pc?.connectionState === 'connected' && videoTrack)
+                finish();
+        };
+        const poll = setInterval(() => {
+            if (settled) {
+                clearInterval(poll);
+                return;
+            }
+            if (pc) {
+                pc.connectionStateChange.subscribe(state => {
+                    if (state === 'failed' || state === 'closed')
+                        finish(new Error(`LiveKit subscriber connection ${state}.`));
+                    else
+                        check();
+                });
+                pc.onTrack.subscribe(() => check());
+                clearInterval(poll);
+            }
+        }, 100);
+    });
+
+    return { pc: pc!, videoTrack, audioTrack, close: cleanup };
+}
+
+/**
+ * Minimal RTCSignalingSession wrapper around a werift peer connection, adapted from
+ * @scrypted/webrtc's WeriftSignalingSession.
+ */
+class WeriftSignalingSession implements RTCSignalingSession {
+    __proxy_props = { options: {} };
+    options: RTCSignalingOptions = {};
+    remoteDescription?: Promise<void>;
+
+    constructor(public console: ConsoleLike, public pc: RTCPeerConnection) {
+    }
+
+    async getOptions(): Promise<RTCSignalingOptions> {
+        return this.options;
+    }
+
+    async createLocalDescription(type: 'offer' | 'answer', setup: RTCAVSignalingSetup, sendIceCandidate: undefined | RTCSignalingSendIceCandidate): Promise<RTCSessionDescriptionInit> {
+        this.pc.onIceCandidate.subscribe(candidate => {
+            sendIceCandidate?.({
+                candidate: candidate.candidate,
+                sdpMid: candidate.sdpMid,
+                sdpMLineIndex: candidate.sdpMLineIndex,
+            });
+        });
+
+        if (type === 'offer') {
+            const offer = await this.pc.createOffer();
+            this.pc.setLocalDescription(offer);
+            return { type: offer.type, sdp: offer.sdp };
+        }
+
+        if (!sendIceCandidate)
+            await this.remoteDescription;
+        const answer = await this.pc.createAnswer();
+        this.pc.setLocalDescription(answer);
+        return { type: answer.type, sdp: answer.sdp };
+    }
+
+    async setRemoteDescription(description: RTCSessionDescriptionInit, setup: RTCAVSignalingSetup): Promise<void> {
+        this.remoteDescription = this.pc.setRemoteDescription(description as any);
+        await this.remoteDescription;
+    }
+
+    async addIceCandidate(candidate: RTCIceCandidateInit): Promise<void> {
+        await this.pc.addIceCandidate(new RTCIceCandidate(candidate as any));
+    }
+}
+
+function createCandidateQueue(console: ConsoleLike, session: RTCSignalingSession) {
+    let ready = false;
+    let queue: RTCIceCandidateInit[] = [];
+    const send = async (candidate: RTCIceCandidateInit) => {
+        try {
+            await session.addIceCandidate(candidate);
+        }
+        catch (e) {
+            console.error('addIceCandidate error', e);
+        }
+    };
+    return {
+        flush() {
+            ready = true;
+            for (const candidate of queue)
+                send(candidate);
+            queue = [];
+        },
+        queueSendCandidate: async (candidate: RTCIceCandidateInit) => {
+            if (!ready)
+                queue.push(candidate);
+            else
+                send(candidate);
+        },
+    };
+}
+
+/**
+ * Negotiate an offer/answer pair between two signaling clients. Adapted from
+ * @scrypted/webrtc's connectRTCSignalingClients.
+ */
+async function connectRTCSignalingClients(
+    console: ConsoleLike,
+    offerClient: RTCSignalingSession,
+    offerSetup: Partial<RTCAVSignalingSetup>,
+    answerClient: RTCSignalingSession,
+    answerSetup: Partial<RTCAVSignalingSetup>,
+) {
+    offerSetup.type = 'offer';
+    answerSetup.type = 'answer';
+
+    const answerQueue = createCandidateQueue(console, answerClient);
+    const offerQueue = createCandidateQueue(console, offerClient);
+
+    const offer = await offerClient.createLocalDescription('offer', offerSetup as RTCAVSignalingSetup, answerQueue.queueSendCandidate);
+    await answerClient.setRemoteDescription(offer, answerSetup as RTCAVSignalingSetup);
+    const answer = await answerClient.createLocalDescription('answer', answerSetup as RTCAVSignalingSetup, offerQueue.queueSendCandidate);
+    await offerClient.setRemoteDescription(answer, offerSetup as RTCAVSignalingSetup);
+    offerQueue.flush();
+    answerQueue.flush();
+}
+
+/**
+ * Manages a single shared LiveKit subscriber connection per camera and fans it out to multiple
+ * Scrypted consumers.
+ *
+ * Scrypted requests a stream several times concurrently (console preview, rebroadcast, NVR, etc.),
+ * each calling startRTCSignalingSession. If each opened its own LiveKit connection, they would all
+ * join the same room with the SAME participant identity (from the user's token) — and LiveKit
+ * disconnects the existing participant whenever another joins with a duplicate identity, so the
+ * connections kick each other out (intermittent "connection failed" / black screen). Instead we
+ * keep one upstream subscriber and bridge every consumer off its tracks, tearing the upstream down
+ * only when the last consumer leaves.
+ */
+export class LiveKitCameraStream {
+    private viewer?: LiveKitViewer;
+    private viewerPromise?: Promise<LiveKitViewer>;
+    private refcount = 0;
+
+    constructor(
+        private getDetails: () => Promise<LiveKitDetails>,
+        private console: ConsoleLike,
+        private debug: () => boolean,
+    ) {
+    }
+
+    private dlog(...args: any[]): void {
+        if (this.debug())
+            this.console.log(...args);
+    }
+
+    private viewerHealthy(viewer: LiveKitViewer): boolean {
+        const state = viewer.pc.connectionState;
+        return state !== 'failed' && state !== 'closed';
+    }
+
+    private async ensureViewer(): Promise<LiveKitViewer> {
+        if (this.viewer && this.viewerHealthy(this.viewer))
+            return this.viewer;
+
+        if (!this.viewerPromise) {
+            this.viewerPromise = (async () => {
+                const details = await this.getDetails();
+                const viewer = await startLiveKitViewer(details, this.console, this.debug);
+                this.dlog('SS:LiveKit subscriber connected; bridging to Scrypted.',
+                    'video=', viewer.videoTrack?.codec?.mimeType ?? false,
+                    'audio=', viewer.audioTrack?.codec?.mimeType ?? false);
+                this.viewer = viewer;
+                viewer.pc.connectionStateChange.subscribe(state => {
+                    if ((state === 'failed' || state === 'closed') && this.viewer === viewer) {
+                        this.viewer = undefined;
+                        this.viewerPromise = undefined;
+                    }
+                });
+                return viewer;
+            })();
+            this.viewerPromise.catch(() => { this.viewerPromise = undefined; });
+        }
+        return this.viewerPromise;
+    }
+
+    async startSession(session: RTCSignalingSession): Promise<RTCSessionControl> {
+        const viewer = await this.ensureViewer();
+        this.refcount++;
+        try {
+            return await bridgeToScryptedSession(session, viewer, this.console, () => this.release());
+        }
+        catch (err) {
+            this.release();
+            throw err;
+        }
+    }
+
+    private release(): void {
+        this.refcount = Math.max(0, this.refcount - 1);
+        if (this.refcount === 0) {
+            this.viewer?.close();
+            this.viewer = undefined;
+            this.viewerPromise = undefined;
+        }
+    }
+}
+
+async function bridgeToScryptedSession(
+    session: RTCSignalingSession,
+    viewer: LiveKitViewer,
+    console: ConsoleLike,
+    onEnd: () => void,
+): Promise<RTCSessionControl> {
+
+    // Match the consumer peer connection's codecs to what LiveKit negotiated so RTP can be
+    // forwarded without transcoding (payload types line up).
+    const videoCodec = viewer.videoTrack?.codec;
+    const audioCodec = viewer.audioTrack?.codec;
+    const codecs: { video?: RTCRtpCodecParameters[]; audio?: RTCRtpCodecParameters[] } = {};
+    if (videoCodec)
+        codecs.video = [videoCodec];
+    if (audioCodec)
+        codecs.audio = [audioCodec];
+
+    const consumerPc = new RTCPeerConnection({
+        bundlePolicy: 'max-bundle',
+        codecs,
+    });
+
+    // Outbound tracks fed by forwarding RTP from the LiveKit tracks.
+    const videoOut = new MediaStreamTrack({ kind: 'video' });
+    consumerPc.addTransceiver(videoOut, { direction: 'sendonly' });
+    viewer.videoTrack?.onReceiveRtp.subscribe(rtp => videoOut.writeRtp(rtp));
+
+    let audioOut: MediaStreamTrack | undefined;
+    if (viewer.audioTrack) {
+        audioOut = new MediaStreamTrack({ kind: 'audio' });
+        consumerPc.addTransceiver(audioOut, { direction: 'sendonly' });
+        viewer.audioTrack.onReceiveRtp.subscribe(rtp => audioOut!.writeRtp(rtp));
+    }
+
+    const weriftSession = new WeriftSignalingSession(console, consumerPc);
+    const consumerSetup: Partial<RTCAVSignalingSetup> = {
+        audio: { direction: 'sendonly' },
+        video: { direction: 'sendonly' },
+    };
+    const sessionSetup: Partial<RTCAVSignalingSetup> = {
+        audio: { direction: 'recvonly' },
+        video: { direction: 'recvonly' },
+    };
+
+    // If the Scrypted consumer supplies its own offer, it must be the offering side; otherwise we
+    // (werift) offer and the consumer answers.
+    const options = session.options ?? await session.getOptions?.();
+    if (options?.offer)
+        await connectRTCSignalingClients(console, session, sessionSetup, weriftSession, consumerSetup);
+    else
+        await connectRTCSignalingClients(console, weriftSession, consumerSetup, session, sessionSetup);
+
+    const control = new SimplisafeRTCSessionControl(() => {
+        try { consumerPc.close(); } catch { /* ignore */ }
+        // Release this consumer's hold on the shared LiveKit connection; the streamer tears the
+        // upstream down only when the last consumer leaves.
+        onEnd();
+    });
+
+    consumerPc.connectionStateChange.subscribe(state => {
+        if (state === 'failed' || state === 'closed')
+            control.endSession().catch(() => { /* ignore */ });
+    });
+    viewer.pc.connectionStateChange.subscribe(state => {
+        if (state === 'failed' || state === 'closed')
+            control.endSession().catch(() => { /* ignore */ });
+    });
+
+    return control;
+}
+
+/**
+ * Returned to Scrypted's WebRTC plugin. Must be a class instance (not a plain object literal) so
+ * Scrypted's RPC passes it by reference/proxy instead of trying to structured-clone its methods.
+ */
+class SimplisafeRTCSessionControl implements RTCSessionControl {
+    private ended = false;
+
+    constructor(private teardown: () => void) {
+    }
+
+    async getRefreshAt(): Promise<number | void> {
+        // No forced refresh. LiveKit only validates the access token at join time; a connected
+        // participant is not disconnected when the token expires. Forcing a refresh would mean
+        // reconnecting the shared upstream, which would interrupt every current viewer. If the
+        // upstream ever does drop, the shared connection self-heals on the next stream request
+        // (each reconnect fetches a fresh token), so no periodic refresh is needed.
+        return undefined;
+    }
+
+    async extendSession(): Promise<void> {
+    }
+
+    async setPlayback(): Promise<void> {
+    }
+
+    async endSession(): Promise<void> {
+        if (this.ended)
+            return;
+        this.ended = true;
+        this.teardown();
+    }
+}

--- a/src/livekit.ts
+++ b/src/livekit.ts
@@ -42,6 +42,18 @@ const SUBSCRIBE_VIDEO_CODECS = [
         ],
         parameters: 'level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=42e01f',
     }),
+    // Accept RTX retransmissions. Without this, the SFU has no channel to answer our NACKs and
+    // most upstream packet loss is unrecoverable (observed ~0.4% net video loss -> HomeKit frame
+    // drops). LiveKit's payload type mapping is stable (H264 on 125, its rtx on 126/apt=125), and
+    // werift keeps every remote rtx whose apt origin matches a local codec, so mirroring one pair
+    // is enough to accept them all. payloadType MUST be explicit: werift's constructor rewrites
+    // the apt parameter of any rtx codec it auto-assigns a payload type to.
+    new RTCRtpCodecParameters({
+        mimeType: 'video/rtx',
+        clockRate: 90000,
+        payloadType: 126,
+        parameters: 'apt=125',
+    }),
 ];
 const SUBSCRIBE_AUDIO_CODECS = [
     new RTCRtpCodecParameters({
@@ -233,6 +245,44 @@ class H264KeyframeCapturer {
     }
 }
 
+/**
+ * RTP sequence-continuity accounting for diagnosing packet loss. Tracks forward gaps (packets
+ * skipped), late arrivals (retransmissions/reordering filling earlier gaps), and duplicates.
+ * `lost` is net loss after late arrivals are credited back.
+ */
+class RtpSeqStats {
+    received = 0;
+    gapEvents = 0;
+    lost = 0;
+    reordered = 0;
+    private expected?: number;
+
+    onPacket(seq: number): void {
+        this.received++;
+        if (this.expected === undefined) {
+            this.expected = (seq + 1) & 0xffff;
+            return;
+        }
+        if (seq === this.expected) {
+            this.expected = (seq + 1) & 0xffff;
+            return;
+        }
+        const delta = (seq - this.expected) & 0xffff;
+        if (delta < 0x8000) {
+            // Jumped forward: delta packets were skipped.
+            this.gapEvents++;
+            this.lost += delta;
+            this.expected = (seq + 1) & 0xffff;
+        }
+        else {
+            // Behind the high-water mark: a late (retransmitted/reordered) packet filled a gap.
+            this.reordered++;
+            if (this.lost > 0)
+                this.lost--;
+        }
+    }
+}
+
 interface LiveKitViewer {
     pc: RTCPeerConnection;
     videoTrack?: MediaStreamTrack;
@@ -283,6 +333,25 @@ async function startLiveKitViewer(details: LiveKitDetails, console: ConsoleLike,
     let videoTrack: MediaStreamTrack | undefined;
     let audioTrack: MediaStreamTrack | undefined;
     const keyframeCapturer = new H264KeyframeCapturer();
+    // Packet-loss diagnostics: sequence continuity at the earliest point we see LiveKit RTP.
+    const videoStats = new RtpSeqStats();
+    const audioStats = new RtpSeqStats();
+    let nackSends = 0;
+    let statsTimer: NodeJS.Timeout | undefined;
+    let lastStatsLine = '';
+    const startStatsLogging = () => {
+        if (statsTimer)
+            return;
+        statsTimer = setInterval(() => {
+            const line = `SS:rtpstats video recv=${videoStats.received} lost=${videoStats.lost} gaps=${videoStats.gapEvents} late=${videoStats.reordered}`
+                + ` | audio recv=${audioStats.received} lost=${audioStats.lost}`
+                + ` | nackSends=${nackSends}`;
+            if (line !== lastStatsLine) {
+                lastStatsLine = line;
+                dlog(line);
+            }
+        }, 10_000);
+    };
     let pingTimer: NodeJS.Timeout | undefined;
     let remoteDescriptionSet = false;
     const pendingCandidates: RTCIceCandidate[] = [];
@@ -341,6 +410,8 @@ async function startLiveKitViewer(details: LiveKitDetails, console: ConsoleLike,
     const cleanup = () => {
         if (pingTimer)
             clearInterval(pingTimer);
+        if (statsTimer)
+            clearInterval(statsTimer);
         if (micMuteTimer)
             clearTimeout(micMuteTimer);
         try { ws.close(); } catch { /* ignore */ }
@@ -381,12 +452,30 @@ async function startLiveKitViewer(details: LiveKitDetails, console: ConsoleLike,
                 videoTrack = track;
                 // Passively watch the video RTP to retain the latest keyframe for on-demand snapshots.
                 track.onReceiveRtp.subscribe(rtp => {
+                    videoStats.onPacket(rtp.header.sequenceNumber);
                     try { keyframeCapturer.onRtp(rtp); }
                     catch { /* ignore malformed packet */ }
                 });
+                // Observe werift's NACK handler so the stats show whether retransmission requests
+                // are actually being sent for the gaps we see.
+                try {
+                    const receiver = (pc!.getTransceivers() as any[])
+                        .find(t => t?.receiver?.tracks?.includes?.(track) || t?.kind === 'video')?.receiver;
+                    if (receiver) {
+                        dlog('SS:rtpstats video nackEnabled=', !!receiver.nackEnabled);
+                        receiver.nack?.onPacketLost?.subscribe?.(() => { nackSends++; });
+                    }
+                }
+                catch (e) {
+                    dlog('SS:rtpstats receiver introspection failed', e);
+                }
+                startStatsLogging();
             }
-            else if (track.kind === 'audio')
+            else if (track.kind === 'audio') {
                 audioTrack = track;
+                track.onReceiveRtp.subscribe(rtp => audioStats.onPacket(rtp.header.sequenceNumber));
+                startStatsLogging();
+            }
         });
     };
 
@@ -426,12 +515,20 @@ async function startLiveKitViewer(details: LiveKitDetails, console: ConsoleLike,
                     const h264 = (offer.sdp.match(/a=(rtpmap|fmtp):.*(H264|h264).*/g) || []).join(' | ');
                     if (h264)
                         dlog('SS:LiveKit server H264 offer:', h264);
+                    // Loss diagnostics: does the server offer retransmission (rtx) / FEC, and does it
+                    // pair ssrcs for it (ssrc-group FID)?
+                    const resilience = (offer.sdp.match(/a=(rtpmap:\d+ (rtx|red|ulpfec|flexfec).*|fmtp:\d+ apt=\d+|ssrc-group:FID.*)/g) || []).join(' | ');
+                    if (resilience)
+                        dlog('SS:LiveKit server offer resilience:', resilience);
                     await pc.setRemoteDescription({ type: 'offer', sdp: offer.sdp });
                     remoteDescriptionSet = true;
                     for (const candidate of pendingCandidates.splice(0))
                         await pc.addIceCandidate(candidate).catch(() => { /* ignore */ });
                     const answer = await pc.createAnswer();
                     await pc.setLocalDescription(answer);
+                    const answerVideo = (answer.sdp.match(/a=rtpmap:.*/g) || []).join(' | ');
+                    if (answerVideo)
+                        dlog('SS:LiveKit our answer rtpmap:', answerVideo);
                     send({
                         case: 'answer',
                         value: new SessionDescription({ type: 'answer', sdp: answer.sdp, id: offer.id }),

--- a/src/livekit.ts
+++ b/src/livekit.ts
@@ -486,12 +486,14 @@ async function startLiveKitViewer(details: LiveKitDetails, console: ConsoleLike,
     });
 
     const handleSignal = async (data: WebSocket.RawData) => {
+        let messageCase: string | undefined;
         try {
             const bytes = data instanceof Buffer ? new Uint8Array(data)
                 : data instanceof ArrayBuffer ? new Uint8Array(data)
                 : new Uint8Array(data as any);
             const resp = SignalResponse.fromBinary(bytes);
             const msg = resp.message;
+            messageCase = msg.case;
 
             switch (msg.case) {
                 case 'join': {
@@ -600,6 +602,14 @@ async function startLiveKitViewer(details: LiveKitDetails, console: ConsoleLike,
         }
         catch (err) {
             console.warn('Failed to handle LiveKit signaling message.', err);
+            // A failed offer exchange (e.g. werift crashing on an SFU renegotiation that adds an
+            // m-line) leaves the server waiting for an answer it will never get; it kicks the
+            // session seconds later regardless. Tear down now so the shared viewer resets and
+            // consumers reconnect immediately instead of streaming into a doomed session.
+            if (messageCase === 'offer') {
+                console.warn('SS:LiveKit offer negotiation failed; restarting subscriber connection.');
+                cleanup();
+            }
         }
     };
 

--- a/src/livekit.ts
+++ b/src/livekit.ts
@@ -118,6 +118,14 @@ type ConsoleLike = Pick<Console, 'log' | 'warn' | 'error'>;
 const LK_PROTOCOL = 15;
 const LK_VERSION = '2.20.0';
 
+// LiveKit's join response includes its TURN server, and @koush/ice's TurnClient keeps refreshing
+// its allocation after pc.close() — every 10-minute session rollover leaks a refresh loop that
+// spams unhandledRejection TransactionFailed indefinitely. Filtering TURN out was tried
+// (2026-07-05) and BROKE streaming: the SimpliSafe SFU is not directly reachable, media goes via
+// the relay, and the server drops the participant (signaling ws closes) when ICE cannot form. So
+// TURN must stay on; the refresh leak needs fixing in werift instead.
+const USE_TURN_SERVERS = true;
+
 /**
  * Flatten LiveKit ICE servers (protobuf ICEServer with a `urls` array) into werift's expected
  * shape (one entry per url string).
@@ -130,12 +138,19 @@ function normalizeIceServers(iceServers: any[] | undefined): any[] {
         const urls = ice?.urls ?? ice?.url;
         const credential = ice?.credential ?? ice?.password;
         const username = ice?.username;
+        const push = (url: unknown) => {
+            if (typeof url !== 'string')
+                return;
+            if (!USE_TURN_SERVERS && /^turns?:/i.test(url.trim()))
+                return;
+            ret.push({ urls: url, username, credential });
+        };
         if (Array.isArray(urls)) {
             for (const url of urls)
-                ret.push({ urls: url, username, credential });
+                push(url);
         }
-        else if (typeof urls === 'string') {
-            ret.push({ urls, username, credential });
+        else {
+            push(urls);
         }
     }
     return ret;
@@ -506,7 +521,45 @@ async function startLiveKitViewer(details: LiveKitDetails, console: ConsoleLike,
         return true;
     };
 
+    // werift never stops the TURN allocation-refresh loop or closes its UDP socket on pc.close()
+    // (@koush/ice's TurnTransport has no close method, and TurnClient.refreshHandle is never
+    // cancelled), so every closed session leaks a refresh loop that spams unhandledRejection
+    // TransactionFailed once its allocation credentials lapse. Stop them explicitly.
+    const stopTurnClients = (peer?: RTCPeerConnection) => {
+        for (const ice of (peer as any)?.iceTransports ?? []) {
+            for (const protocol of ice?.connection?.protocols ?? []) {
+                const turn = protocol?.turn;
+                if (!turn)
+                    continue;
+                try { turn.refreshHandle?.cancel?.(); } catch { /* ignore */ }
+                // The cancelled refresh loop still completes its in-flight iteration (it re-checks
+                // its flag only after the ~500s sleep), issuing one final REFRESH from a detached
+                // async context. Left alone that request can only time out, surfacing as an
+                // unhandledRejection TransactionTimeout minutes after every close; resolve it
+                // immediately instead.
+                try { turn.request = async () => []; } catch { /* ignore */ }
+                // Stop the retry timers of transactions already in flight. Their promises are
+                // never settled, which is rejection-free and GC-safe.
+                try {
+                    for (const transaction of Object.values(turn.transactions ?? {}))
+                        (transaction as any)?.cancel?.();
+                } catch { /* ignore */ }
+                const transport = turn.transport;
+                if (!transport)
+                    continue;
+                // Swap send out BEFORE closing the socket: pc.close() completes asynchronously
+                // (DTLS close_notify, final RTCP), and any late send hitting the closed dgram
+                // socket rejects uncaught ('Not running') from werift's send promise.
+                try { transport.send = async () => { /* socket closed */ }; } catch { /* ignore */ }
+                try { transport.close?.(); } catch { /* ignore */ }
+            }
+        }
+    };
+
     const cleanup = () => {
+        // Re-entrant: pc.close() below re-fires connectionStateChange('closed') into cleanup.
+        if (closed)
+            return;
         closed = true;
         if (pingTimer)
             clearInterval(pingTimer);
@@ -519,6 +572,8 @@ async function startLiveKitViewer(details: LiveKitDetails, console: ConsoleLike,
         try { ws.close(); } catch { /* ignore */ }
         try { pc?.close(); } catch { /* ignore */ }
         try { publisherPc?.close(); } catch { /* ignore */ }
+        stopTurnClients(pc);
+        stopTurnClients(publisherPc);
         for (const cb of closedCallbacks.splice(0)) {
             try { cb(); } catch { /* ignore */ }
         }
@@ -552,8 +607,14 @@ async function startLiveKitViewer(details: LiveKitDetails, console: ConsoleLike,
             });
         });
 
-        pc.connectionStateChange.subscribe(state =>
-            dlog(`SS:LiveKit subscriber pc ${state} at ${ts()}`));
+        pc.connectionStateChange.subscribe(state => {
+            dlog(`SS:LiveKit subscriber pc ${state} at ${ts()}`);
+            // A post-startup failure gets no leave message, so without this the viewer lingers as
+            // a zombie: onClosed never fires, consumers hang on frozen video, and ensureViewer
+            // keeps handing out the dead session.
+            if (state === 'failed' || state === 'closed')
+                cleanup();
+        });
         pc.iceConnectionStateChange.subscribe(state =>
             dlog(`SS:LiveKit subscriber ice ${state} at ${ts()}`));
 
@@ -776,7 +837,12 @@ async function startLiveKitViewer(details: LiveKitDetails, console: ConsoleLike,
     ws.on('message', (data: WebSocket.RawData) => {
         signalQueue = signalQueue.then(() => handleSignal(data));
     });
-    ws.on('close', () => dlog('SS:LiveKit ws closed.'));
+    ws.on('close', () => {
+        dlog('SS:LiveKit ws closed.');
+        // An unexpected websocket drop (network blip, server restart) must tear the viewer down so
+        // consumers are notified and the next stream request builds a fresh session.
+        cleanup();
+    });
 
     // Wait for the subscriber peer connection to connect and deliver at least a video track.
     await new Promise<void>((resolve, reject) => {
@@ -1081,9 +1147,18 @@ export class LiveKitCameraStream {
         return viewer.ensureMicTrack();
     }
 
-    /** Fired when the stream truly ends (active session died with no replacement). */
-    onStreamEnded(cb: () => void): void {
+    /**
+     * Fired when the stream truly ends (active session died with no replacement). Returns an
+     * unregister function so consumer sessions that end first don't accumulate here for the
+     * stream's lifetime.
+     */
+    onStreamEnded(cb: () => void): () => void {
         this.streamEndedCbs.push(cb);
+        return () => {
+            const index = this.streamEndedCbs.indexOf(cb);
+            if (index >= 0)
+                this.streamEndedCbs.splice(index, 1);
+        };
     }
 
     private fireStreamEnded(): void {
@@ -1192,6 +1267,15 @@ export class LiveKitCameraStream {
         if (this.viewer && this.viewer.isHealthy())
             return this.viewer;
 
+        if (this.viewer) {
+            // Unhealthy but not yet torn down: close it (which fires onClosed and clears
+            // viewer/viewerPromise) so the request below builds a fresh session instead of being
+            // handed the dead one via the stale viewerPromise.
+            try { this.viewer.close(); } catch { /* ignore */ }
+            this.viewer = undefined;
+            this.viewerPromise = undefined;
+        }
+
         if (!this.viewerPromise) {
             this.viewerPromise = (async () => {
                 const details = await this.getDetails();
@@ -1289,10 +1373,15 @@ async function bridgeToScryptedSession(
         codecs,
     });
 
+    // The relays outlive this session (they are camera-lifetime), so every subscription made here
+    // must be disposed on session end — otherwise each session permanently leaks a per-packet
+    // callback writing into its dead tracks.
+    const sessionDisposers: (() => void)[] = [];
+
     // Outbound video, fed from the stream's stable relay (survives session rollovers).
     const videoOut = new MediaStreamTrack({ kind: 'video' });
     consumerPc.addTransceiver(videoOut, { direction: 'sendonly' });
-    stream.videoRelay.onReceiveRtp.subscribe(rtp => videoOut.writeRtp(rtp));
+    sessionDisposers.push(stream.videoRelay.onReceiveRtp.subscribe(rtp => videoOut.writeRtp(rtp)).unSubscribe);
 
     // Audio is bidirectional. We send the camera's audio to the consumer AND accept talk-back (the
     // viewer's microphone) on the same transceiver: Scrypted's WebRTC plugin implements HomeKit
@@ -1302,7 +1391,7 @@ async function bridgeToScryptedSession(
     if (audioCodec) {
         const audioOut = new MediaStreamTrack({ kind: 'audio' });
         consumerPc.addTransceiver(audioOut, { direction: 'sendrecv' });
-        stream.audioRelay.onReceiveRtp.subscribe(rtp => audioOut.writeRtp(rtp));
+        sessionDisposers.push(stream.audioRelay.onReceiveRtp.subscribe(rtp => audioOut.writeRtp(rtp)).unSubscribe);
     }
     else {
         consumerPc.addTransceiver('audio', { direction: 'recvonly' });
@@ -1355,6 +1444,9 @@ async function bridgeToScryptedSession(
         await connectRTCSignalingClients(console, weriftSession, consumerSetup, session, sessionSetup);
 
     const control = new SimplisafeRTCSessionControl(() => {
+        for (const dispose of sessionDisposers.splice(0)) {
+            try { dispose(); } catch { /* ignore */ }
+        }
         try { consumerPc.close(); } catch { /* ignore */ }
         // Release this consumer's hold on the shared LiveKit connection; the streamer tears the
         // upstream down only when the last consumer leaves. The shared mic track is not torn down
@@ -1368,9 +1460,9 @@ async function bridgeToScryptedSession(
     });
     // End the consumer session only when the stream truly ends (active session died with no
     // replacement) — NOT on session rollovers, which consumers ride through via the relays.
-    stream.onStreamEnded(() => {
+    sessionDisposers.push(stream.onStreamEnded(() => {
         control.endSession().catch(() => { /* ignore */ });
-    });
+    }));
 
     return control;
 }

--- a/src/livekit.ts
+++ b/src/livekit.ts
@@ -128,11 +128,118 @@ function normalizeIceServers(iceServers: any[] | undefined): any[] {
     return ret;
 }
 
+const H264_START_CODE = Buffer.from([0x00, 0x00, 0x00, 0x01]);
+
+/**
+ * Reassembles the camera's H264 RTP into Annex-B access units and retains the most recent keyframe
+ * (SPS + PPS + IDR). This lets the plugin produce a still from the already-flowing WebRTC video
+ * without cold-starting a fresh stream — the slow, timeout-prone path that otherwise makes HomeKit
+ * show "Snapshot Failed". werift's H264RtpPayload does not reassemble FU-A fragments (how keyframe
+ * slices almost always arrive), so RFC 6184 depacketization is done here.
+ */
+class H264KeyframeCapturer {
+    private sps?: Buffer;
+    private pps?: Buffer;
+    private auNals: Buffer[] = [];
+    private auHasIdr = false;
+    private auHasSps = false;
+    private auHasPps = false;
+    private auTimestamp?: number;
+    private fuBuffer?: Buffer;
+    private latest?: Buffer;
+
+    get keyframe(): Buffer | undefined {
+        return this.latest;
+    }
+
+    onRtp(rtp: RtpPacket): void {
+        const buf = rtp.payload;
+        if (!buf || buf.length < 1)
+            return;
+
+        // A change in RTP timestamp marks a new access unit; flush the previous one. (The marker bit
+        // handled below is the primary boundary; this is a fallback when markers are unreliable.)
+        const timestamp = rtp.header.timestamp;
+        if (this.auTimestamp !== undefined && timestamp !== this.auTimestamp)
+            this.finishAccessUnit();
+        this.auTimestamp = timestamp;
+
+        const nalType = buf[0] & 0x1f;
+        if (nalType >= 1 && nalType <= 23) {
+            // Single NAL unit packet.
+            this.pushNal(buf);
+        }
+        else if (nalType === 24) {
+            // STAP-A: one packet aggregating several NAL units (commonly SPS + PPS).
+            let offset = 1;
+            while (offset + 2 <= buf.length) {
+                const size = buf.readUInt16BE(offset);
+                offset += 2;
+                if (size === 0 || offset + size > buf.length)
+                    break;
+                this.pushNal(buf.subarray(offset, offset + size));
+                offset += size;
+            }
+        }
+        else if (nalType === 28) {
+            // FU-A: a single NAL unit fragmented across packets.
+            if (buf.length < 2)
+                return;
+            const fuHeader = buf[1];
+            const start = (fuHeader & 0x80) !== 0;
+            const end = (fuHeader & 0x40) !== 0;
+            const fragment = buf.subarray(2);
+            if (start) {
+                const nalHeader = (buf[0] & 0xe0) | (fuHeader & 0x1f);
+                this.fuBuffer = Buffer.concat([Buffer.from([nalHeader]), fragment]);
+            }
+            else if (this.fuBuffer) {
+                this.fuBuffer = Buffer.concat([this.fuBuffer, fragment]);
+            }
+            if (end && this.fuBuffer) {
+                this.pushNal(this.fuBuffer);
+                this.fuBuffer = undefined;
+            }
+        }
+        // STAP-B / FU-B / MTAP are not used by these cameras and are ignored.
+
+        if (rtp.header.marker)
+            this.finishAccessUnit();
+    }
+
+    private pushNal(nal: Buffer): void {
+        const type = nal[0] & 0x1f;
+        if (type === 7) { this.sps = nal; this.auHasSps = true; }
+        else if (type === 8) { this.pps = nal; this.auHasPps = true; }
+        else if (type === 5) this.auHasIdr = true;
+        this.auNals.push(nal);
+    }
+
+    private finishAccessUnit(): void {
+        if (this.auHasIdr && this.auNals.length) {
+            const parts: Buffer[] = [];
+            // Ensure the still is decodable even if the camera sent parameter sets in an earlier AU.
+            if (this.sps && !this.auHasSps) parts.push(H264_START_CODE, this.sps);
+            if (this.pps && !this.auHasPps) parts.push(H264_START_CODE, this.pps);
+            for (const nal of this.auNals) parts.push(H264_START_CODE, nal);
+            this.latest = Buffer.concat(parts);
+        }
+        this.auNals = [];
+        this.auHasIdr = false;
+        this.auHasSps = false;
+        this.auHasPps = false;
+        this.fuBuffer = undefined;
+        this.auTimestamp = undefined;
+    }
+}
+
 interface LiveKitViewer {
     pc: RTCPeerConnection;
     videoTrack?: MediaStreamTrack;
     audioTrack?: MediaStreamTrack;
     close: () => void;
+    /** The most recent decode-ready H264 keyframe (Annex-B SPS+PPS+IDR), if any has been seen. */
+    getKeyframe: () => Buffer | undefined;
     /**
      * Lazily publish a single shared talk-back (microphone) track to LiveKit over this same
      * participant connection and return it. Callers write RTP into the returned track; it is
@@ -175,6 +282,7 @@ async function startLiveKitViewer(details: LiveKitDetails, console: ConsoleLike,
     let pc: RTCPeerConnection | undefined;
     let videoTrack: MediaStreamTrack | undefined;
     let audioTrack: MediaStreamTrack | undefined;
+    const keyframeCapturer = new H264KeyframeCapturer();
     let pingTimer: NodeJS.Timeout | undefined;
     let remoteDescriptionSet = false;
     const pendingCandidates: RTCIceCandidate[] = [];
@@ -269,8 +377,14 @@ async function startLiveKitViewer(details: LiveKitDetails, console: ConsoleLike,
         });
 
         pc.onTrack.subscribe(track => {
-            if (track.kind === 'video')
+            if (track.kind === 'video') {
                 videoTrack = track;
+                // Passively watch the video RTP to retain the latest keyframe for on-demand snapshots.
+                track.onReceiveRtp.subscribe(rtp => {
+                    try { keyframeCapturer.onRtp(rtp); }
+                    catch { /* ignore malformed packet */ }
+                });
+            }
             else if (track.kind === 'audio')
                 audioTrack = track;
         });
@@ -520,7 +634,7 @@ async function startLiveKitViewer(details: LiveKitDetails, console: ConsoleLike,
         return micPublish;
     };
 
-    return { pc: pc!, videoTrack, audioTrack, close: cleanup, ensureMicTrack, claimMic, writeMic };
+    return { pc: pc!, videoTrack, audioTrack, close: cleanup, getKeyframe: () => keyframeCapturer.keyframe, ensureMicTrack, claimMic, writeMic };
 }
 
 /**
@@ -655,6 +769,14 @@ export class LiveKitCameraStream {
     private viewerHealthy(viewer: LiveKitViewer): boolean {
         const state = viewer.pc.connectionState;
         return state !== 'failed' && state !== 'closed';
+    }
+
+    /**
+     * The latest H264 keyframe (Annex-B) from the active viewer, if one is currently connected.
+     * Returns undefined when the camera is idle (no live video is flowing).
+     */
+    getKeyframe(): Buffer | undefined {
+        return this.viewer?.getKeyframe();
     }
 
     private async ensureViewer(): Promise<LiveKitViewer> {

--- a/src/livekit.ts
+++ b/src/livekit.ts
@@ -1118,7 +1118,7 @@ export class LiveKitCameraStream {
     private micSinkHolds = 0;
 
     constructor(
-        private getDetails: () => Promise<LiveKitDetails>,
+        private getDetails: (force?: boolean) => Promise<LiveKitDetails>,
         private console: ConsoleLike,
         private debug: () => boolean,
     ) {
@@ -1273,7 +1273,12 @@ export class LiveKitCameraStream {
         return this.viewer?.getKeyframe();
     }
 
-    private async ensureViewer(): Promise<LiveKitViewer> {
+    /**
+     * @param force ask the details supplier to bypass any active API backoff. Set for viewer
+     * creation driven by a consumer actually asking for video, so a user pressing play retries now;
+     * the scheduled rollover leaves it unset and respects the backoff.
+     */
+    private async ensureViewer(force = false): Promise<LiveKitViewer> {
         if (this.viewer && this.viewer.isHealthy())
             return this.viewer;
 
@@ -1288,7 +1293,7 @@ export class LiveKitCameraStream {
 
         if (!this.viewerPromise) {
             this.viewerPromise = (async () => {
-                const details = await this.getDetails();
+                const details = await this.getDetails(force);
                 const viewer = await startLiveKitViewer(details, this.console, this.debug, this.makeSinks(++this.genCounter));
                 this.dlog('SS:LiveKit subscriber connected; bridging to Scrypted.',
                     'video=', viewer.videoCodec?.mimeType ?? false,
@@ -1310,7 +1315,7 @@ export class LiveKitCameraStream {
     }
 
     async startSession(session: RTCSignalingSession): Promise<RTCSessionControl> {
-        await this.ensureViewer();
+        await this.ensureViewer(true);
         this.refcount++;
         try {
             return await bridgeToScryptedSession(session, this, this.console, () => this.release());

--- a/src/main.ts
+++ b/src/main.ts
@@ -1544,9 +1544,14 @@ class SimplisafeCamera extends ScryptedDeviceBase implements Camera, VideoCamera
 
             socket.on('message', buf => {
                 try {
+                    // Resolve the track per packet: after a forced mid-talk session rollover the
+                    // shared mic lives on the replacement viewer, not the one at acquire time.
+                    const track = sink.getTrack();
+                    if (!track)
+                        return;
                     const pkt = RtpPacket.deSerialize(buf);
-                    pkt.header.payloadType = sink.track.codec?.payloadType ?? 111;
-                    sink.track.writeRtp(pkt);
+                    pkt.header.payloadType = track.codec?.payloadType ?? 111;
+                    track.writeRtp(pkt);
                 }
                 catch {
                     /* ignore malformed packet */
@@ -1615,6 +1620,7 @@ class SimplisafePlugin extends ScryptedDeviceBase implements DeviceProvider, Set
     private readonly uuidToNativeId = new Map<string, string>();
     private readonly identifierToNativeIds = new Map<string, Set<string>>();
     private readonly currentNativeIds = new Set<string>();
+    private readonly deviceCreations = new Map<string, Promise<SimplisafeCamera>>();
     private readonly readinessTasks = new Map<string, Promise<void>>();
     private readonly upgradedNativeIds = new Set<string>();
     private readonly readinessStorageKey = 'cameraReadiness';
@@ -2316,6 +2322,20 @@ class SimplisafePlugin extends ScryptedDeviceBase implements DeviceProvider, Set
             return existing;
         }
 
+        // Scrypted can request the same device concurrently. createDevice awaits (initialize/sync)
+        // between the cache check and construction, so without memoization both callers would
+        // construct and the duplicate-instance guard would throw for the loser.
+        let creation = this.deviceCreations.get(normalized);
+        if (!creation) {
+            creation = this.createDevice(nativeId, normalized).finally(() => {
+                this.deviceCreations.delete(normalized);
+            });
+            this.deviceCreations.set(normalized, creation);
+        }
+        return creation;
+    }
+
+    private async createDevice(nativeId: string, normalized: string): Promise<SimplisafeCamera> {
         let lookupNativeId = normalized;
 
         if (!this.cameraDetails.has(lookupNativeId)) {
@@ -2341,6 +2361,14 @@ class SimplisafePlugin extends ScryptedDeviceBase implements DeviceProvider, Set
                     this.console.warn(`SimpliSafe camera ${lookupNativeId} could not be refreshed during device retrieval. Falling back to cached details.`, err);
                 }
             }
+        }
+
+        // A concurrent caller may have created this device under an alias while we awaited (the
+        // memoization above only dedupes identical requested ids, and legacy ids redirect here).
+        // Everything from this check to construction is synchronous, so this closes the race.
+        const concurrentlyCreated = this.devices.get(lookupNativeId);
+        if (concurrentlyCreated) {
+            return concurrentlyCreated;
         }
 
         let details = this.cameraDetails.get(lookupNativeId);

--- a/src/main.ts
+++ b/src/main.ts
@@ -38,8 +38,6 @@ import { ChildProcess, spawn } from 'child_process';
 import { EventEmitter } from 'events';
 import crypto from 'crypto';
 import dgram from 'dgram';
-import dns from 'dns';
-const { lookup } = dns.promises;
 import jpegExtract from 'jpeg-extract';
 import WebSocket, { RawData } from 'ws';
 
@@ -61,7 +59,10 @@ const subscriptionCacheTime = 3000;
 const cameraCacheTime = 15000;
 const rateLimitInitialInterval = 60_000;
 const rateLimitMaxInterval = 2 * 60 * 60 * 1000;
-const mediaHostTtl = 5 * 60 * 1000;
+// Media requests carry the SimpliSafe bearer token, so they must go to the hostname with TLS
+// verification enabled — never to a resolved IP with verification disabled (MITM could steal the
+// token, which grants full account access including the alarm).
+const SS_MEDIA_HOST = 'media.simplisafe.com';
 // Recording providers known to serve the SimpliSafe cloud FLV streaming endpoint.
 // Add the value logged by SS:isUnsupported here once confirmed it works with the FLV path.
 const SUPPORTED_RECORDING_PROVIDERS = new Set<string>(['simplisafe']);
@@ -976,8 +977,6 @@ class SimplisafeCamera extends ScryptedDeviceBase implements Camera, VideoCamera
     private liveKitStream?: LiveKitCameraStream;
     private streamOptions?: ResponseMediaStreamOptions[];
     private pictureOptions?: ResponsePictureOptions[];
-    private mediaHost?: string;
-    private mediaHostTimestamp = 0;
     private simplisafeUuid?: string;
     private ready = false;
     private desiredOnline = true;
@@ -1217,10 +1216,12 @@ class SimplisafeCamera extends ScryptedDeviceBase implements Camera, VideoCamera
 
             const width = selected.video?.width ?? 1920;
             const accessToken = await this.api.getAccessToken();
-            const host = await this.getMediaHost();
-            const url = `https://${host}/v1/${details.uuid}/flv?x=${width}&audioEncoding=AAC`;
+            const url = `https://${SS_MEDIA_HOST}/v1/${details.uuid}/flv?x=${width}&audioEncoding=AAC`;
             const inputArguments = [
                 '-re',
+                // ffmpeg skips TLS certificate verification by default; the Authorization header
+                // below must not be exposed to a MITM.
+                '-tls_verify', '1',
                 '-headers',
                 `Authorization: Bearer ${accessToken}`,
                 '-i',
@@ -1271,15 +1272,13 @@ class SimplisafeCamera extends ScryptedDeviceBase implements Camera, VideoCamera
                 ?? 1920;
 
             const accessToken = await this.api.getAccessToken();
-            const host = await this.getMediaHost();
-            const snapshotUrl = `https://${host}/v1/${details.uuid}/mjpg?x=${width}&fr=1`;
+            const snapshotUrl = `https://${SS_MEDIA_HOST}/v1/${details.uuid}/mjpg?x=${width}&fr=1`;
 
             const image = await jpegExtract({
                 url: snapshotUrl,
                 headers: {
                     Authorization: `Bearer ${accessToken}`,
                 },
-                rejectUnauthorized: false,
             });
 
             return this.createMediaObject(image, 'image/jpeg');
@@ -1436,27 +1435,6 @@ class SimplisafeCamera extends ScryptedDeviceBase implements Camera, VideoCamera
         }
 
         return height;
-    }
-
-    private async getMediaHost(): Promise<string> {
-        const now = Date.now();
-        if (!this.mediaHost || now - this.mediaHostTimestamp > mediaHostTtl) {
-            try {
-                const result = await lookup('media.simplisafe.com');
-                this.mediaHost = result.address;
-                this.mediaHostTimestamp = now;
-            } catch (err) {
-                if (!this.mediaHost) {
-                    this.console.warn('Unable to resolve media.simplisafe.com, falling back to hostname.', err);
-                    this.mediaHost = 'media.simplisafe.com';
-                    this.mediaHostTimestamp = now;
-                } else {
-                    this.console.warn('Unable to resolve media.simplisafe.com, using cached host.', err);
-                }
-            }
-        }
-
-        return this.mediaHost!;
     }
 
     private getCameraName(details: SimplisafeCameraDetails): string {

--- a/src/main.ts
+++ b/src/main.ts
@@ -11,6 +11,7 @@ import sdk, {
     DeviceState,
     DeviceProvider,
     FFmpegInput,
+    Intercom,
     MediaObject,
     MotionSensor,
     RequestMediaStreamOptions,
@@ -23,16 +24,20 @@ import sdk, {
     ScryptedDeviceBase,
     ScryptedDeviceType,
     ScryptedInterface,
+    ScryptedMimeTypes,
     Setting,
     SettingValue,
     Settings,
     VideoCamera,
 } from '@scrypted/sdk';
 import { LiveKitCameraStream, LiveViewResponse } from './livekit';
+import { RtpPacket } from '@koush/werift';
 import axios, { AxiosError, AxiosInstance, AxiosRequestConfig } from 'axios';
 import axiosRetry from 'axios-retry';
+import { ChildProcess, spawn } from 'child_process';
 import { EventEmitter } from 'events';
 import crypto from 'crypto';
+import dgram from 'dgram';
 import dns from 'dns';
 const { lookup } = dns.promises;
 import jpegExtract from 'jpeg-extract';
@@ -943,7 +948,7 @@ class SimplisafeApi extends EventEmitter {
     }
 }
 
-class SimplisafeCamera extends ScryptedDeviceBase implements Camera, VideoCamera, Settings, MotionSensor, RTCSignalingChannel {
+class SimplisafeCamera extends ScryptedDeviceBase implements Camera, VideoCamera, Settings, MotionSensor, RTCSignalingChannel, Intercom {
     private static instanceRegistry = new Map<string, string>();
     private readonly nativeCameraId: string;
     private readonly api: SimplisafeApi;
@@ -965,6 +970,9 @@ class SimplisafeCamera extends ScryptedDeviceBase implements Camera, VideoCamera
     private readonly motionHoldDurationMs = 5_000;
     motionDetected?: boolean;
     motionDetectedTimestamp?: number;
+    private intercomProcess?: ChildProcess;
+    private intercomSocket?: dgram.Socket;
+    private intercomCleanup?: () => void;
 
     constructor(
         nativeId: string,
@@ -1421,6 +1429,92 @@ class SimplisafeCamera extends ScryptedDeviceBase implements Camera, VideoCamera
         return this.liveKitStream;
     }
 
+    /**
+     * Two-way audio (talk-back). Scrypted/HomeKit hands us the return audio as an FFmpegInput; we
+     * transcode it to Opus RTP, feed it to a werift track, and publish that track upstream to
+     * LiveKit over the shared participant connection.
+     */
+    async startIntercom(media: MediaObject): Promise<void> {
+        this.logInstanceUsage('startIntercom');
+        const details = await this.ensureDetails();
+        if (!this.isLiveKitCamera(details)) {
+            throw new Error(`${this.getDisplayName()} does not support two-way audio.`);
+        }
+
+        // Tear down any prior intercom session before starting a new one.
+        await this.stopIntercom();
+
+        const ffmpegInput = await mediaManager.convertMediaObjectToJSON<FFmpegInput>(media, ScryptedMimeTypes.FFmpegInput);
+        const ffmpegPath = await mediaManager.getFFmpegPath();
+
+        try {
+            // Acquire the shared LiveKit talk-back sink (published once, reused across sessions).
+            const sink = await this.getLiveKitStream(details.uuid).acquireMicSink();
+            this.intercomCleanup = sink.release;
+
+            // Bind a UDP socket so we can tell ffmpeg which port to emit Opus RTP to.
+            const socket = dgram.createSocket('udp4');
+            this.intercomSocket = socket;
+            // An unhandled dgram 'error' would surface as an uncaughtException and kill the plugin.
+            socket.on('error', err => this.console.error('SimpliSafe intercom socket error.', err));
+            const port = await new Promise<number>((resolve, reject) => {
+                socket.once('error', reject);
+                socket.bind(0, '127.0.0.1', () => resolve(socket.address().port));
+            });
+
+            socket.on('message', buf => {
+                try {
+                    const pkt = RtpPacket.deSerialize(buf);
+                    pkt.header.payloadType = sink.track.codec?.payloadType ?? 111;
+                    sink.track.writeRtp(pkt);
+                }
+                catch {
+                    /* ignore malformed packet */
+                }
+            });
+
+            const args = [
+                ...ffmpegInput.inputArguments!,
+                '-vn',
+                '-acodec', 'libopus',
+                '-ac', '2',
+                '-ar', '48000',
+                '-application', 'lowdelay',
+                '-f', 'rtp',
+                '-payload_type', '111',
+                `rtp://127.0.0.1:${port}`,
+            ];
+            if (this.getDebug())
+                this.console.log('SS:startIntercom ffmpeg', ffmpegPath, args.join(' '));
+
+            const cp = spawn(ffmpegPath, args, {
+                env: ffmpegInput.env ? { ...process.env, ...ffmpegInput.env } : process.env,
+            });
+            this.intercomProcess = cp;
+            cp.on('error', err => this.console.error('SimpliSafe intercom ffmpeg error.', err));
+            cp.stderr?.on('data', data => {
+                if (this.getDebug())
+                    this.console.log('SS:intercom ffmpeg', data.toString());
+            });
+            cp.on('exit', () => { this.stopIntercom().catch(() => { /* ignore */ }); });
+        }
+        catch (err) {
+            this.console.error(`Failed to start SimpliSafe talk-back for ${this.nativeCameraId}.`, err);
+            await this.stopIntercom();
+            throw err;
+        }
+    }
+
+    async stopIntercom(): Promise<void> {
+        this.logInstanceUsage('stopIntercom');
+        try { this.intercomCleanup?.(); } catch { /* ignore */ }
+        this.intercomCleanup = undefined;
+        try { this.intercomProcess?.kill('SIGKILL'); } catch { /* ignore */ }
+        this.intercomProcess = undefined;
+        try { this.intercomSocket?.close(); } catch { /* ignore */ }
+        this.intercomSocket = undefined;
+    }
+
     async getSettings(): Promise<Setting[]> {
         this.logInstanceUsage('getSettings');
         return [];
@@ -1663,6 +1757,8 @@ class SimplisafePlugin extends ScryptedDeviceBase implements DeviceProvider, Set
 
         if (liveKit) {
             interfaces.push(ScryptedInterface.RTCSignalingChannel);
+            // LiveKit cameras support two-way audio by publishing a mic track upstream.
+            interfaces.push(ScryptedInterface.Intercom);
         }
 
         const name = details.cameraSettings?.cameraName

--- a/src/main.ts
+++ b/src/main.ts
@@ -17,6 +17,9 @@ import sdk, {
     RequestPictureOptions,
     ResponseMediaStreamOptions,
     ResponsePictureOptions,
+    RTCSessionControl,
+    RTCSignalingChannel,
+    RTCSignalingSession,
     ScryptedDeviceBase,
     ScryptedDeviceType,
     ScryptedInterface,
@@ -25,6 +28,7 @@ import sdk, {
     Settings,
     VideoCamera,
 } from '@scrypted/sdk';
+import { LiveKitCameraStream, LiveViewResponse } from './livekit';
 import axios, { AxiosError, AxiosInstance, AxiosRequestConfig } from 'axios';
 import axiosRetry from 'axios-retry';
 import { EventEmitter } from 'events';
@@ -53,6 +57,9 @@ const cameraCacheTime = 15000;
 const rateLimitInitialInterval = 60_000;
 const rateLimitMaxInterval = 2 * 60 * 60 * 1000;
 const mediaHostTtl = 5 * 60 * 1000;
+// Recording providers known to serve the SimpliSafe cloud FLV streaming endpoint.
+// Add the value logged by SS:isUnsupported here once confirmed it works with the FLV path.
+const SUPPORTED_RECORDING_PROVIDERS = new Set<string>(['simplisafe']);
 const socketRetryInterval = 1000;
 const socketHeartbeatInterval = 60_000;
 const socketRetryBackoffCap = 60_000;
@@ -94,6 +101,13 @@ interface SimplisafeCameraSettings {
 
 interface SimplisafeCameraProviders {
     recording?: string;
+    webrtc?: string;
+    live?: string;
+    allSupportedProviders?: {
+        webrtc?: string[];
+        recording?: string[];
+        live?: string[];
+    };
 }
 
 interface SimplisafeCameraSupportedFeatures {
@@ -146,6 +160,16 @@ interface SimplisafeRealtimeMessage {
     type?: string;
     data?: SimplisafeRealtimeEvent;
     [key: string]: unknown;
+}
+
+/**
+ * Newer SimpliSafe cameras stream over LiveKit (WebRTC) instead of the legacy FLV endpoint.
+ * SimpliSafe labels them with providers.webrtc === 'kvs' (typically with live === 'none'), but the
+ * live-view endpoint actually returns LiveKit connection details, not Amazon KVS.
+ */
+function isLiveKitCameraDetails(details: SimplisafeCameraDetails): boolean {
+    const providers = details.supportedFeatures?.providers;
+    return providers?.webrtc === 'kvs' || providers?.recording === 'kvs';
 }
 
 function normalizeIdSegment(value: string): string {
@@ -718,6 +742,36 @@ class SimplisafeApi extends EventEmitter {
         return this.authManager.accessToken;
     }
 
+    /**
+     * Fetch the LiveKit live-view bundle for a newer SimpliSafe camera. Returns
+     * { liveKitDetails: { liveKitURL, userToken }, cameraStatus }. Uses the app-hub host rather
+     * than the standard api.simplisafe.com/v1 base (an absolute url overrides the axios baseURL).
+     */
+    async getLiveView(cameraUuid: string): Promise<LiveViewResponse> {
+        // Ensure the subscription/location id is resolved; getSubscription populates this.subId.
+        await this.getSubscription();
+        const locationId = this.subId;
+        if (!locationId) {
+            throw new Error('Unable to determine SimpliSafe location id for live view.');
+        }
+
+        const raw = await this.request<any>({
+            method: 'GET',
+            url: `https://app-hub.prd.aser.simplisafe.com/v2/cameras/${cameraUuid}/${locationId}/live-view`,
+        });
+
+        // Tolerate a wrapped envelope (e.g. { data: {...} }). The token is short-lived.
+        const body: LiveViewResponse = raw?.liveKitDetails ? raw
+            : raw?.data?.liveKitDetails ? raw.data
+            : raw;
+
+        if (this.debug) {
+            this.log.log(`SS:liveView ${cameraUuid} liveKitURL=${body?.liveKitDetails?.liveKitURL} cameraStatus=${body?.cameraStatus}`);
+        }
+
+        return body;
+    }
+
     async getCameras(forceRefresh = false): Promise<SimplisafeCameraDetails[]> {
         if (!forceRefresh && this.cameraCache && Date.now() - this.cameraCache.timestamp < cameraCacheTime) {
             if (this.debug) {
@@ -889,7 +943,7 @@ class SimplisafeApi extends EventEmitter {
     }
 }
 
-class SimplisafeCamera extends ScryptedDeviceBase implements Camera, VideoCamera, Settings, MotionSensor {
+class SimplisafeCamera extends ScryptedDeviceBase implements Camera, VideoCamera, Settings, MotionSensor, RTCSignalingChannel {
     private static instanceRegistry = new Map<string, string>();
     private readonly nativeCameraId: string;
     private readonly api: SimplisafeApi;
@@ -899,6 +953,7 @@ class SimplisafeCamera extends ScryptedDeviceBase implements Camera, VideoCamera
     private readonly statusCallback: (ready: boolean, desiredOnline: boolean) => void;
     private readonly instanceId: string;
     private details?: SimplisafeCameraDetails;
+    private liveKitStream?: LiveKitCameraStream;
     private streamOptions?: ResponseMediaStreamOptions[];
     private pictureOptions?: ResponsePictureOptions[];
     private mediaHost?: string;
@@ -982,6 +1037,9 @@ class SimplisafeCamera extends ScryptedDeviceBase implements Camera, VideoCamera
             const cameras = await this.api.getCameras(forceRefresh);
             const details = cameras.find(camera => this.matchesCamera(camera));
             if (details) {
+                if (this.getDebug()) {
+                    this.console.log(`SS:rawCameraDetails ${this.nativeCameraId} ${JSON.stringify(details)}`);
+                }
                 this.updateDetails(details);
                 return details;
             }
@@ -1090,7 +1148,8 @@ class SimplisafeCamera extends ScryptedDeviceBase implements Camera, VideoCamera
 
     async getVideoStreamOptions(): Promise<ResponseMediaStreamOptions[]> {
         this.logInstanceUsage('getVideoStreamOptions');
-        console.log('SS:getVideoStreamOptions', this.nativeCameraId);
+        if (this.getDebug())
+            this.console.log('SS:getVideoStreamOptions', this.nativeCameraId);
         try {
             const details = await this.ensureDetails();
 
@@ -1107,9 +1166,14 @@ class SimplisafeCamera extends ScryptedDeviceBase implements Camera, VideoCamera
 
     async getVideoStream(options?: RequestMediaStreamOptions): Promise<MediaObject> {
         this.logInstanceUsage('getVideoStream');
-        console.log('SS:getVideoStream', this.nativeCameraId, options);
+        if (this.getDebug())
+            this.console.log('SS:getVideoStream', this.nativeCameraId, options);
         try {
             const details = await this.ensureDetails();
+
+            if (this.isLiveKitCamera(details)) {
+                throw new Error(`${this.getDisplayName()} streams over WebRTC; use the RTCSignalingChannel path, not getVideoStream.`);
+            }
 
             if (this.isUnsupported(details)) {
                 throw new Error(`${this.getDisplayName()} does not support SimpliSafe cloud streaming.`);
@@ -1151,9 +1215,16 @@ class SimplisafeCamera extends ScryptedDeviceBase implements Camera, VideoCamera
 
     async takePicture(options?: RequestPictureOptions): Promise<MediaObject> {
         this.logInstanceUsage('takePicture');
-        try {
-            const details = await this.ensureDetails();
+        const details = await this.ensureDetails();
 
+        // LiveKit cameras have no snapshot endpoint, and the SFU won't reliably hand out a keyframe
+        // on demand for an idle camera. Reject quietly so Scrypted's Snapshot plugin derives the
+        // still from the rebroadcast prebuffer (and caches it) instead.
+        if (this.isLiveKitCamera(details)) {
+            throw new Error(`${this.getDisplayName()} does not support direct snapshot capture; derived from the WebRTC stream.`);
+        }
+
+        try {
             if (this.isUnsupported(details)) {
                 throw new Error(`${this.getDisplayName()} does not support snapshots.`);
             }
@@ -1294,9 +1365,60 @@ class SimplisafeCamera extends ScryptedDeviceBase implements Camera, VideoCamera
         return `Camera ${this.nativeCameraId}`;
     }
 
+    /**
+     * Newer SimpliSafe cameras stream over LiveKit (WebRTC), reported as providers.webrtc === 'kvs'
+     * (and typically live === 'none'), instead of the legacy FLV endpoint.
+     */
+    isLiveKitCamera(details: SimplisafeCameraDetails): boolean {
+        return isLiveKitCameraDetails(details);
+    }
+
     private isUnsupported(details: SimplisafeCameraDetails): boolean {
-        return details.supportedFeatures?.providers?.recording !== undefined
-            && details.supportedFeatures.providers.recording !== 'simplisafe';
+        // LiveKit cameras are supported via the WebRTC/RTCSignalingChannel path, not FLV.
+        if (this.isLiveKitCamera(details)) {
+            return false;
+        }
+        const provider = details.supportedFeatures?.providers?.recording;
+        const unsupported = provider !== undefined && !SUPPORTED_RECORDING_PROVIDERS.has(provider);
+        if (unsupported && this.getDebug()) {
+            this.console.log(
+                `SS:isUnsupported ${this.getDisplayName()} recordingProvider=${JSON.stringify(provider)} ` +
+                `supportedFeatures=${JSON.stringify(details.supportedFeatures)}`);
+        }
+        return unsupported;
+    }
+
+    async startRTCSignalingSession(session: RTCSignalingSession): Promise<RTCSessionControl | undefined> {
+        this.logInstanceUsage('startRTCSignalingSession');
+        const details = await this.ensureDetails();
+        if (!this.isLiveKitCamera(details)) {
+            throw new Error(`${this.getDisplayName()} does not support WebRTC streaming.`);
+        }
+
+        try {
+            return await this.getLiveKitStream(details.uuid).startSession(session);
+        } catch (err) {
+            this.console.error(`Failed to start SimpliSafe WebRTC stream for ${this.nativeCameraId}.`, err);
+            throw err;
+        }
+    }
+
+    /** One shared LiveKit connection per camera, fanned out to all Scrypted consumers. */
+    private getLiveKitStream(cameraUuid: string): LiveKitCameraStream {
+        if (!this.liveKitStream) {
+            this.liveKitStream = new LiveKitCameraStream(async () => {
+                const liveView = await this.api.getLiveView(cameraUuid);
+                const liveKit = liveView.liveKitDetails;
+                if (!liveKit?.liveKitURL || !liveKit?.userToken) {
+                    throw new Error(`${this.getDisplayName()} live-view response did not include LiveKit details.`);
+                }
+                if (this.getDebug()) {
+                    this.console.log(`SS:liveView ${this.nativeCameraId} liveKitURL=${liveKit.liveKitURL} cameraStatus=${liveView.cameraStatus}`);
+                }
+                return liveKit;
+            }, this.console, this.getDebug);
+        }
+        return this.liveKitStream;
     }
 
     async getSettings(): Promise<Setting[]> {
@@ -1523,7 +1645,10 @@ class SimplisafePlugin extends ScryptedDeviceBase implements DeviceProvider, Set
             return;
         }
 
-        const includeVideoCamera = this.upgradedNativeIds.has(nativeId);
+        const liveKit = isLiveKitCameraDetails(details);
+        // LiveKit cameras stream over WebRTC (RTCSignalingChannel); the FLV VideoCamera path is
+        // dead for them. Legacy cameras keep VideoCamera, added after the readiness probe.
+        const includeVideoCamera = !liveKit && this.upgradedNativeIds.has(nativeId);
         const interfaces: (ScryptedInterface | string)[] = [
             ScryptedInterface.Camera,
             ScryptedInterface.Settings,
@@ -1534,6 +1659,10 @@ class SimplisafePlugin extends ScryptedDeviceBase implements DeviceProvider, Set
 
         if (includeVideoCamera) {
             interfaces.push(ScryptedInterface.VideoCamera);
+        }
+
+        if (liveKit) {
+            interfaces.push(ScryptedInterface.RTCSignalingChannel);
         }
 
         const name = details.cameraSettings?.cameraName
@@ -1857,7 +1986,11 @@ class SimplisafePlugin extends ScryptedDeviceBase implements DeviceProvider, Set
                 this.cachedDescriptors.set(normalized, stored);
                 const key = this.computeDescriptorKey(stored);
                 this.lastPublished.set(normalized, key);
-                if (stored.interfaces.includes(ScryptedInterface.VideoCamera) || stored.interfaces.includes('VideoCamera')) {
+                const streamingReady = stored.interfaces.includes(ScryptedInterface.VideoCamera)
+                    || stored.interfaces.includes('VideoCamera')
+                    || stored.interfaces.includes(ScryptedInterface.RTCSignalingChannel)
+                    || stored.interfaces.includes('RTCSignalingChannel');
+                if (streamingReady) {
                     this.upgradedNativeIds.add(normalized);
                     if (!this.cameraReady.has(normalized)) {
                         this.cameraReady.set(normalized, true);

--- a/src/main.ts
+++ b/src/main.ts
@@ -606,6 +606,9 @@ class SimplisafeApi extends EventEmitter {
     }
 
     private handleSocketMessage(raw: RawData): void {
+        if (this.debug) {
+            this.log.log(`SimpliSafe realtime: raw message: ${raw.toString()}`);
+        }
         let message: SimplisafeRealtimeMessage;
         try {
             message = JSON.parse(raw.toString());
@@ -647,17 +650,29 @@ class SimplisafeApi extends EventEmitter {
         }
 
         if (data.sid && this.subId && data.sid !== this.subId) {
+            if (this.debug) {
+                this.log.log(`SimpliSafe realtime: dropping event for other subscription sid=${data.sid} (ours=${this.subId}).`);
+            }
             return;
         }
 
         switch (data.eventCid) {
         case 1170:
+            if (this.debug) {
+                this.log.log(`SimpliSafe realtime: camera motion event payload: ${JSON.stringify(data)}`);
+            }
             this.emit(EVENT_TYPES.CAMERA_MOTION, data);
             break;
         case 1458:
+            if (this.debug) {
+                this.log.log(`SimpliSafe realtime: doorbell event payload: ${JSON.stringify(data)}`);
+            }
             this.emit(EVENT_TYPES.DOORBELL, data);
             break;
         default:
+            if (this.debug) {
+                this.log.log(`SimpliSafe realtime: unhandled event cid=${data.eventCid ?? 'unknown'} payload: ${JSON.stringify(data)}`);
+            }
             break;
         }
     }
@@ -968,7 +983,10 @@ class SimplisafeCamera extends ScryptedDeviceBase implements Camera, VideoCamera
     private desiredOnline = true;
     private motionResetTimer?: NodeJS.Timeout;
     private readonly motionHoldDurationMs = 5_000;
-    motionDetected?: boolean;
+    // NOTE: motionDetected must NOT be re-declared as a class field here. Under
+    // useDefineForClassFields (target ESNext) a field declaration installs an own
+    // property that shadows ScryptedDeviceBase's prototype accessor, so assignments
+    // would never reach Scrypted device state (or HomeKit).
     motionDetectedTimestamp?: number;
     private intercomProcess?: ChildProcess;
     private intercomSocket?: dgram.Socket;
@@ -1617,6 +1635,7 @@ class SimplisafePlugin extends ScryptedDeviceBase implements DeviceProvider, Set
     private readonly cameraDetails = new Map<string, SimplisafeCameraDetails>();
     private readonly nativeIdToUuid = new Map<string, string>();
     private readonly uuidToNativeId = new Map<string, string>();
+    private readonly identifierToNativeIds = new Map<string, Set<string>>();
     private readonly currentNativeIds = new Set<string>();
     private readonly readinessTasks = new Map<string, Promise<void>>();
     private readonly upgradedNativeIds = new Set<string>();
@@ -1680,17 +1699,60 @@ class SimplisafePlugin extends ScryptedDeviceBase implements DeviceProvider, Set
         this.uuidToNativeId.delete(uuid.toLowerCase());
     }
 
+    private registerCameraIdentifiers(nativeId: string, details: SimplisafeCameraDetails): void {
+        const normalizedNativeId = this.normalizeNativeId(nativeId);
+        this.unregisterCameraIdentifiers(normalizedNativeId);
+        const identifiers: (string | undefined)[] = [
+            (details as any)?.serialNumber,
+            (details as any)?.serial,
+            (details as any)?.deviceSerial,
+            (details as any)?.macAddress,
+            (details as any)?.mac,
+            details.uuid,
+        ];
+        for (const identifier of identifiers) {
+            if (typeof identifier !== 'string') {
+                continue;
+            }
+            const trimmed = identifier.trim();
+            if (!trimmed) {
+                continue;
+            }
+            for (const key of new Set([trimmed.toLowerCase(), normalizeIdSegment(trimmed)])) {
+                if (!key) {
+                    continue;
+                }
+                let nativeIds = this.identifierToNativeIds.get(key);
+                if (!nativeIds) {
+                    nativeIds = new Set<string>();
+                    this.identifierToNativeIds.set(key, nativeIds);
+                }
+                nativeIds.add(normalizedNativeId);
+            }
+        }
+    }
+
+    private unregisterCameraIdentifiers(nativeId: string): void {
+        const normalizedNativeId = this.normalizeNativeId(nativeId);
+        for (const [key, nativeIds] of this.identifierToNativeIds) {
+            if (nativeIds.delete(normalizedNativeId) && nativeIds.size === 0) {
+                this.identifierToNativeIds.delete(key);
+            }
+        }
+    }
+
     private handleCameraMotionEvent(event: SimplisafeRealtimeEvent): void {
         const nativeIds = this.resolveNativeIdsFromEvent(event);
         if (nativeIds.length === 0) {
+            const identifier = event.sensorSerial
+                || event.cameraSerial
+                || event.serial
+                || event.deviceSerial
+                || event.cameraUuid
+                || event.uuid;
+            this.console.warn(`SimpliSafe motion event could not be matched to a camera. identifier=${identifier ?? 'unknown'}`);
             if (this.debug) {
-                const identifier = event.sensorSerial
-                    || event.cameraSerial
-                    || event.serial
-                    || event.deviceSerial
-                    || event.cameraUuid
-                    || event.uuid;
-                this.console.warn(`SimpliSafe motion event could not be matched to a camera. identifier=${identifier ?? 'unknown'}`);
+                this.console.warn(`Unmatched motion event payload: ${JSON.stringify(event)}`);
             }
             return;
         }
@@ -1723,13 +1785,27 @@ class SimplisafePlugin extends ScryptedDeviceBase implements DeviceProvider, Set
 
         const resolved = new Set<string>();
         for (const candidate of candidates) {
+            // The event may carry the nativeId itself, a bare serial/uuid, or a
+            // serial that only matches after full segment normalization.
             const normalized = this.normalizeNativeId(candidate);
             if (this.cameraDetails.has(normalized)) {
                 resolved.add(normalized);
             }
+            const prefixed = `simplisafe-camera-${normalizeIdSegment(candidate)}`;
+            if (this.cameraDetails.has(prefixed)) {
+                resolved.add(prefixed);
+            }
             const mapped = this.uuidToNativeId.get(candidate) ?? this.uuidToNativeId.get(candidate.toLowerCase());
             if (mapped) {
                 resolved.add(mapped);
+            }
+            for (const key of new Set([normalized, normalizeIdSegment(candidate)])) {
+                const indexed = this.identifierToNativeIds.get(key);
+                if (indexed) {
+                    for (const nativeId of indexed) {
+                        resolved.add(nativeId);
+                    }
+                }
             }
         }
 
@@ -1955,6 +2031,7 @@ class SimplisafePlugin extends ScryptedDeviceBase implements DeviceProvider, Set
         }
 
         this.cameraDetails.set(normalized, details);
+        this.registerCameraIdentifiers(normalized, details);
         this.pendingRemoval.delete(normalized);
 
         if (details.uuid) {
@@ -2090,6 +2167,7 @@ class SimplisafePlugin extends ScryptedDeviceBase implements DeviceProvider, Set
                     this.console.warn(`Duplicate cached SimpliSafe camera nativeId detected: ${nativeId}. Overwriting existing entry.`);
                 }
                 this.cameraDetails.set(nativeId, camera);
+                this.registerCameraIdentifiers(nativeId, camera);
                 if (camera.uuid) {
                     this.nativeIdToUuid.set(nativeId, camera.uuid);
                     this.associateUuidWithNativeId(camera.uuid, nativeId);
@@ -2293,6 +2371,7 @@ class SimplisafePlugin extends ScryptedDeviceBase implements DeviceProvider, Set
         if (!details) {
             details = buildPlaceholderCameraDetails(lookupNativeId, undefined, undefined, simplisafeUuid);
             this.cameraDetails.set(lookupNativeId, details);
+            this.registerCameraIdentifiers(lookupNativeId, details);
             if (!simplisafeUuid && details.uuid) {
                 simplisafeUuid = details.uuid;
                 this.nativeIdToUuid.set(lookupNativeId, simplisafeUuid);
@@ -2541,6 +2620,7 @@ class SimplisafePlugin extends ScryptedDeviceBase implements DeviceProvider, Set
                 }
                 this.nativeIdToUuid.delete(legacy);
                 this.cameraDetails.delete(legacy);
+                this.unregisterCameraIdentifiers(legacy);
                 this.cameraReady.delete(legacy);
                 this.cameraDesiredOnline.delete(legacy);
                 this.cameraLastOnline.delete(legacy);

--- a/src/main.ts
+++ b/src/main.ts
@@ -973,6 +973,9 @@ class SimplisafeCamera extends ScryptedDeviceBase implements Camera, VideoCamera
     private intercomProcess?: ChildProcess;
     private intercomSocket?: dgram.Socket;
     private intercomCleanup?: () => void;
+    private snapshotCache?: Buffer;
+    private snapshotCacheTime = 0;
+    private snapshotRefresh?: Promise<Buffer | undefined>;
 
     constructor(
         nativeId: string,
@@ -1225,10 +1228,16 @@ class SimplisafeCamera extends ScryptedDeviceBase implements Camera, VideoCamera
         this.logInstanceUsage('takePicture');
         const details = await this.ensureDetails();
 
-        // LiveKit cameras have no snapshot endpoint, and the SFU won't reliably hand out a keyframe
-        // on demand for an idle camera. Reject quietly so Scrypted's Snapshot plugin derives the
-        // still from the rebroadcast prebuffer (and caches it) instead.
+        // LiveKit cameras have no snapshot endpoint. Instead of cold-starting the WebRTC->RTSP path
+        // on every request (slow, and prone to timing out as "Snapshot Failed" in HomeKit), serve a
+        // JPEG decoded from the live stream's latest keyframe, cached so idle cameras answer instantly.
         if (this.isLiveKitCamera(details)) {
+            const jpeg = await this.getLiveKitSnapshot();
+            if (jpeg?.length) {
+                return this.createMediaObject(jpeg, 'image/jpeg');
+            }
+            // Nothing streamed yet and nothing cached: fall back to Scrypted's Snapshot plugin, which
+            // derives (and caches) a still from the rebroadcast prebuffer.
             throw new Error(`${this.getDisplayName()} does not support direct snapshot capture; derived from the WebRTC stream.`);
         }
 
@@ -1260,6 +1269,76 @@ class SimplisafeCamera extends ScryptedDeviceBase implements Camera, VideoCamera
             this.console.error(`Failed to capture SimpliSafe snapshot for ${this.nativeCameraId}.`, err);
             throw err;
         }
+    }
+
+    /**
+     * Produce a still for a LiveKit (WebRTC) camera. When a stream is active we decode its latest
+     * H264 keyframe to JPEG and cache it; when idle we serve that cached JPEG immediately. This keeps
+     * HomeKit snapshots instant instead of cold-starting the WebRTC->RTSP path, which is slow and
+     * frequently times out as "Snapshot Failed" once the camera has gone idle for a while.
+     */
+    private async getLiveKitSnapshot(): Promise<Buffer | undefined> {
+        const keyframe = this.liveKitStream?.getKeyframe();
+        // Refresh from a live keyframe at most every few seconds; otherwise reuse the cached JPEG.
+        if (keyframe && Date.now() - this.snapshotCacheTime > 3_000) {
+            if (!this.snapshotRefresh) {
+                this.snapshotRefresh = this.decodeKeyframeToJpeg(keyframe)
+                    .then(jpeg => {
+                        if (jpeg?.length) {
+                            this.snapshotCache = jpeg;
+                            this.snapshotCacheTime = Date.now();
+                        }
+                        return jpeg;
+                    })
+                    .catch(err => {
+                        this.console.warn(`Failed to decode SimpliSafe keyframe snapshot for ${this.nativeCameraId}.`, err);
+                        return undefined;
+                    })
+                    .finally(() => { this.snapshotRefresh = undefined; });
+            }
+            // With no cached image yet, wait for the decode; otherwise serve the stale cache now and
+            // let the refresh finish in the background so this request stays fast.
+            if (!this.snapshotCache) {
+                await this.snapshotRefresh;
+            }
+        }
+        return this.snapshotCache;
+    }
+
+    /** Decode a single Annex-B H264 keyframe to a JPEG using ffmpeg. */
+    private async decodeKeyframeToJpeg(keyframe: Buffer): Promise<Buffer | undefined> {
+        const ffmpegPath = await mediaManager.getFFmpegPath();
+        return await new Promise<Buffer | undefined>((resolve, reject) => {
+            const args = [
+                '-hide_banner', '-loglevel', 'error',
+                '-f', 'h264',
+                '-i', 'pipe:0',
+                '-frames:v', '1',
+                '-f', 'mjpeg',
+                'pipe:1',
+            ];
+            const cp = spawn(ffmpegPath, args);
+            const out: Buffer[] = [];
+            const err: Buffer[] = [];
+            const timer = setTimeout(() => {
+                try { cp.kill('SIGKILL'); } catch { /* ignore */ }
+                reject(new Error('SimpliSafe snapshot decode timed out.'));
+            }, 5_000);
+            cp.stdout.on('data', d => out.push(d));
+            cp.stderr.on('data', d => err.push(d));
+            cp.on('error', e => { clearTimeout(timer); reject(e); });
+            cp.on('close', code => {
+                clearTimeout(timer);
+                const jpeg = Buffer.concat(out);
+                if (jpeg.length)
+                    resolve(jpeg);
+                else
+                    reject(new Error(`ffmpeg snapshot decode failed (code ${code}): ${Buffer.concat(err).toString().trim()}`));
+            });
+            cp.stdin.on('error', () => { /* ignore EPIPE if ffmpeg exits before we finish writing */ });
+            cp.stdin.write(keyframe);
+            cp.stdin.end();
+        });
     }
 
     async getPictureOptions(): Promise<ResponsePictureOptions[]> {
@@ -1404,7 +1483,12 @@ class SimplisafeCamera extends ScryptedDeviceBase implements Camera, VideoCamera
         }
 
         try {
-            return await this.getLiveKitStream(details.uuid).startSession(session);
+            const control = await this.getLiveKitStream(details.uuid).startSession(session);
+            // Seed/refresh the snapshot cache from the now-warm stream so the HomeKit thumbnail is
+            // fresh and later idle snapshots answer instantly instead of cold-starting (and timing
+            // out). The stream sends a keyframe on connect; give it a moment to arrive.
+            setTimeout(() => { this.getLiveKitSnapshot().catch(() => { /* ignore */ }); }, 3_000);
+            return control;
         } catch (err) {
             this.console.error(`Failed to start SimpliSafe WebRTC stream for ${this.nativeCameraId}.`, err);
             throw err;

--- a/src/main.ts
+++ b/src/main.ts
@@ -41,6 +41,7 @@ import crypto from 'crypto';
 import dgram from 'dgram';
 import jpegExtract from 'jpeg-extract';
 import WebSocket, { RawData } from 'ws';
+import packageJson from '../package.json';
 
 const { deviceManager, mediaManager, systemManager } = sdk;
 
@@ -59,7 +60,17 @@ const SS_OAUTH_DEVICE_UUID = '0000007E-0000-1000-8000-0026BB765291';
 const subscriptionCacheTime = 3000;
 const cameraCacheTime = 15000;
 const rateLimitInitialInterval = 60_000;
-const rateLimitMaxInterval = 2 * 60 * 60 * 1000;
+// Keep the ceiling low. A blocked window suppresses every request to that host, so an overlong
+// cap turns a brief upstream fault into an outage that outlives it — the camera would stay dark
+// for hours after SimpliSafe recovered.
+const rateLimitMaxInterval = 5 * 60 * 1000;
+// SimpliSafe fronts app-hub.prd.aser.simplisafe.com with a Kong gateway that 403s requests whose
+// User-Agent starts with a lowercase SDK token — `axios/1.10.0` and `okhttp/4.9.0` are both
+// rejected, while `Axios/1.10.0`, `curl/8.4.0` and an absent UA all pass. Axios sets its own UA by
+// default, so without this every getLiveView() call is refused and WebRTC streaming is dead while
+// the rest of the plugin (api.simplisafe.com, which does not filter) keeps working. Do not remove;
+// if this string ever needs to change, re-test it against /live-view first.
+const SS_USER_AGENT = `scrypted-simplisafe/${packageJson.version}`;
 // Media requests carry the SimpliSafe bearer token, so they must go to the hostname with TLS
 // verification enabled — never to a resolved IP with verification disabled (MITM could steal the
 // token, which grants full account access including the alarm).
@@ -74,6 +85,7 @@ const RESOLUTION_INTERFACE: ScryptedInterface | string = (ScryptedInterface as a
 
 const ssOAuth: AxiosInstance = axios.create({
     baseURL: 'https://auth.simplisafe.com/oauth',
+    headers: { 'User-Agent': SS_USER_AGENT },
 });
 axiosRetry(ssOAuth, { retries: 3 });
 
@@ -436,9 +448,11 @@ class SimplisafeApi extends EventEmitter {
     private subId?: string;
     private lastSubscription?: { id: string; data: any; timestamp: number };
     private cameraCache?: { data: SimplisafeCameraDetails[]; timestamp: number };
-    private isBlocked = false;
-    private nextAttempt = 0;
-    private nextBlockInterval = rateLimitInitialInterval;
+    // Backoff is tracked per host. api.simplisafe.com and app-hub.prd.aser.simplisafe.com are
+    // separate services; letting a failure on one suppress requests to the other is what turned a
+    // single refused endpoint into an outage of the whole integration.
+    private backoff = new Map<string, { nextAttempt: number; interval: number }>();
+    private liveViewRequests = new Map<string, Promise<LiveViewResponse>>();
     private socket?: WebSocket;
     private socketHeartbeat?: NodeJS.Timeout;
     private socketReconnect?: NodeJS.Timeout;
@@ -454,6 +468,7 @@ class SimplisafeApi extends EventEmitter {
         this.debug = debug;
         this.axios = axios.create({
             baseURL: 'https://api.simplisafe.com/v1',
+            headers: { 'User-Agent': SS_USER_AGENT },
         });
         axiosRetry(this.axios, { retries: 2 });
 
@@ -779,29 +794,46 @@ class SimplisafeApi extends EventEmitter {
      * { liveKitDetails: { liveKitURL, userToken }, cameraStatus }. Uses the app-hub host rather
      * than the standard api.simplisafe.com/v1 base (an absolute url overrides the axios baseURL).
      */
-    async getLiveView(cameraUuid: string): Promise<LiveViewResponse> {
-        // Ensure the subscription/location id is resolved; getSubscription populates this.subId.
-        await this.getSubscription();
-        const locationId = this.subId;
-        if (!locationId) {
-            throw new Error('Unable to determine SimpliSafe location id for live view.');
+    async getLiveView(cameraUuid: string, force = false): Promise<LiveViewResponse> {
+        // Consumers restart aggressively on failure (the rebroadcast prebuffer retries every 5s), so
+        // collapse overlapping requests for the same camera into one upstream call. Mirrors the
+        // viewerPromise memoization in LiveKitCameraStream.ensureViewer.
+        const inflight = this.liveViewRequests.get(cameraUuid);
+        if (inflight)
+            return inflight;
+
+        const request = (async () => {
+            // Ensure the subscription/location id is resolved; getSubscription populates this.subId.
+            await this.getSubscription();
+            const locationId = this.subId;
+            if (!locationId) {
+                throw new Error('Unable to determine SimpliSafe location id for live view.');
+            }
+
+            const raw = await this.request<any>({
+                method: 'GET',
+                url: `https://app-hub.prd.aser.simplisafe.com/v2/cameras/${cameraUuid}/${locationId}/live-view`,
+            }, { force });
+
+            // Tolerate a wrapped envelope (e.g. { data: {...} }). The token is short-lived.
+            const body: LiveViewResponse = raw?.liveKitDetails ? raw
+                : raw?.data?.liveKitDetails ? raw.data
+                : raw;
+
+            if (this.debug) {
+                this.log.log(`SS:liveView ${cameraUuid} liveKitURL=${body?.liveKitDetails?.liveKitURL} cameraStatus=${body?.cameraStatus}`);
+            }
+
+            return body;
+        })();
+
+        this.liveViewRequests.set(cameraUuid, request);
+        try {
+            return await request;
         }
-
-        const raw = await this.request<any>({
-            method: 'GET',
-            url: `https://app-hub.prd.aser.simplisafe.com/v2/cameras/${cameraUuid}/${locationId}/live-view`,
-        });
-
-        // Tolerate a wrapped envelope (e.g. { data: {...} }). The token is short-lived.
-        const body: LiveViewResponse = raw?.liveKitDetails ? raw
-            : raw?.data?.liveKitDetails ? raw.data
-            : raw;
-
-        if (this.debug) {
-            this.log.log(`SS:liveView ${cameraUuid} liveKitURL=${body?.liveKitDetails?.liveKitURL} cameraStatus=${body?.cameraStatus}`);
+        finally {
+            this.liveViewRequests.delete(cameraUuid);
         }
-
-        return body;
     }
 
     async getCameras(forceRefresh = false): Promise<SimplisafeCameraDetails[]> {
@@ -843,50 +875,138 @@ class SimplisafeApi extends EventEmitter {
         }
     }
 
-    private async request<T>(config: AxiosRequestConfig): Promise<T> {
-        if (this.isBlocked && Date.now() < this.nextAttempt) {
-            throw new RateLimitError('Blocking request: rate limited');
+    /**
+     * Host the backoff for this request is keyed on. A relative url resolves against the axios
+     * baseURL; getLiveView passes an absolute app-hub url.
+     */
+    private backoffKey(config: AxiosRequestConfig): string {
+        const url = config.url ?? '';
+        if (!/^https?:\/\//i.test(url))
+            return 'api.simplisafe.com';
+        try {
+            return new URL(url).host;
+        }
+        catch {
+            return 'api.simplisafe.com';
+        }
+    }
+
+    /**
+     * Log why a request failed. The response body carries the actual reason (and Kong's request_id,
+     * which SimpliSafe support can correlate); discarding it is what made a hard 403 look like rate
+     * limiting for weeks. Logged at warn/error so it is visible without the debug setting.
+     */
+    private logRequestFailure(config: AxiosRequestConfig, axiosError: AxiosError): void {
+        const method = (config.method ?? 'GET').toUpperCase();
+        const url = config.url ?? '';
+        const response = axiosError.response;
+        if (!response) {
+            this.log.warn(`SimpliSafe ${method} ${url} failed with no response.`, axiosError.message);
+            return;
         }
 
-        const accessToken = await this.getAccessToken();
-
+        const requestId = (response.data as any)?.request_id
+            ?? (response.headers as any)?.['x-kong-request-id'];
+        let body: string;
         try {
-            const response = await this.axios.request<T>({
+            body = typeof response.data === 'string' ? response.data : JSON.stringify(response.data);
+        }
+        catch {
+            body = '<unserializable>';
+        }
+        this.log.error(`SimpliSafe ${method} ${url} -> ${response.status} ${response.statusText}.`
+            + (requestId ? ` request_id=${requestId}.` : '')
+            + ` body=${(body ?? '').slice(0, 300)}`);
+    }
+
+    /**
+     * @param options.force ignore an active backoff window for one attempt. Used by user-initiated
+     * actions so pressing play retries immediately instead of failing until a timer happens to expire.
+     */
+    private async request<T>(config: AxiosRequestConfig, options?: { force?: boolean }): Promise<T> {
+        const key = this.backoffKey(config);
+        const backoff = this.backoff.get(key);
+        if (!options?.force && backoff && Date.now() < backoff.nextAttempt) {
+            const seconds = Math.ceil((backoff.nextAttempt - Date.now()) / 1000);
+            throw new RateLimitError(`Blocking request to ${key}: backing off for another ${seconds}s after a recent failure.`);
+        }
+
+        const send = async () => {
+            const accessToken = await this.getAccessToken();
+            return this.axios.request<T>({
                 ...config,
                 headers: {
                     ...config.headers,
                     Authorization: `${this.authManager.tokenType} ${accessToken}`,
                 },
             });
-            this.resetRateLimit();
+        };
+
+        try {
+            const response = await send();
+            this.resetRateLimit(key);
             return response.data;
-        } catch (error) {
+        }
+        catch (error) {
+            // Local failures (no access token, bad config) are not HTTP problems and must not be
+            // reported as rate limiting.
+            if (!axios.isAxiosError(error))
+                throw error;
+
             const axiosError = error as AxiosError;
+
+            // A 401 means the token went stale, not that the account is blocked. Refresh once and
+            // retry before giving up; on failure fall through to the 401 branch below.
+            if (axiosError.response?.status === 401) {
+                try {
+                    await this.authManager.refreshCredentials();
+                    const response = await send();
+                    this.resetRateLimit(key);
+                    return response.data;
+                }
+                catch {
+                    // fall through with the original 401
+                }
+            }
+
+            this.logRequestFailure(config, axiosError);
+
             if (!axiosError.response) {
-                this.setRateLimit();
+                this.setRateLimit(key);
                 throw new RateLimitError('SimpliSafe request failed: no response received.');
             }
 
-            if (axiosError.response.status === 403) {
-                this.setRateLimit();
-                throw new RateLimitError('SimpliSafe rejected the request (rate limited or auth failure).');
+            const status = axiosError.response.status;
+
+            // 429 is the only status that actually means rate limited.
+            if (status === 429) {
+                const retryAfter = Number((axiosError.response.headers as any)?.['retry-after']);
+                this.setRateLimit(key, Number.isFinite(retryAfter) && retryAfter > 0 ? retryAfter * 1000 : undefined);
+                throw new RateLimitError(`SimpliSafe rate limited requests to ${key}.`);
             }
+
+            if (status === 401)
+                throw new Error('SimpliSafe rejected the stored credentials. Re-authenticate in the plugin settings.');
+
+            // A 403 is a deterministic refusal, not congestion. Backing off would only delay an
+            // identical failure, and suppressing the host would take unrelated features down with
+            // it — see SS_USER_AGENT for the gateway filter that lands here.
+            if (status === 403)
+                throw new Error(`SimpliSafe refused the request to ${key} (403 Forbidden). See the logged response body for the reason.`);
 
             throw axiosError.response.data ?? axiosError;
         }
     }
 
-    private resetRateLimit(): void {
-        this.isBlocked = false;
-        this.nextBlockInterval = rateLimitInitialInterval;
+    private resetRateLimit(key: string): void {
+        this.backoff.delete(key);
     }
 
-    private setRateLimit(): void {
-        this.isBlocked = true;
-        this.nextAttempt = Date.now() + this.nextBlockInterval;
-        if (this.nextBlockInterval < rateLimitMaxInterval) {
-            this.nextBlockInterval *= 2;
-        }
+    private setRateLimit(key: string, retryAfterMs?: number): void {
+        const previous = this.backoff.get(key)?.interval ?? 0;
+        const interval = retryAfterMs
+            ?? Math.min(previous ? previous * 2 : rateLimitInitialInterval, rateLimitMaxInterval);
+        this.backoff.set(key, { nextAttempt: Date.now() + interval, interval });
     }
 
     private async getUserId(): Promise<string> {
@@ -1526,8 +1646,8 @@ class SimplisafeCamera extends ScryptedDeviceBase implements Camera, VideoCamera
     /** One shared LiveKit connection per camera, fanned out to all Scrypted consumers. */
     private getLiveKitStream(cameraUuid: string): LiveKitCameraStream {
         if (!this.liveKitStream) {
-            this.liveKitStream = new LiveKitCameraStream(async () => {
-                const liveView = await this.api.getLiveView(cameraUuid);
+            this.liveKitStream = new LiveKitCameraStream(async (force?: boolean) => {
+                const liveView = await this.api.getLiveView(cameraUuid, force);
                 const liveKit = liveView.liveKitDetails;
                 if (!liveKit?.liveKitURL || !liveKit?.userToken) {
                     throw new Error(`${this.getDisplayName()} live-view response did not include LiveKit details.`);

--- a/src/main.ts
+++ b/src/main.ts
@@ -2206,7 +2206,9 @@ class SimplisafePlugin extends ScryptedDeviceBase implements DeviceProvider, Set
         this.persistCameraReadiness();
         device.markReady();
         await this.refreshDeviceDescriptor(normalized);
-        console.log('SS: camera now ready, advertising VideoCamera:', normalized);
+        // VideoCamera is advertised unconditionally for legacy cameras now, so this probe only
+        // gates the Online state, not the interface list.
+        this.console.log(`SimpliSafe readiness: ${normalized} passed the streaming probe.`);
     }
 
     private async initialize(): Promise<void> {


### PR DESCRIPTION
## Summary
This PR fixes issue #12. It also may fix issue #8.

Newer SimpliSafe cameras use LiveKit WebRTC and this allows those newer cameras to use that. It is a significant change adding livekit.ts with the majority of the changes. 

## Testing
Testing was done on a newer camera that supports this. It passed testing for camera in Scrypted. I also tested with HomeKit and it was able to display the camera, use voice to talk, and send motion events. The motion events work for the newer camera but I am unsure if they work on older cameras. 

Testing still needs to be done on older cameras as well as doorbells. I also just updated the branch to use the recent commits, so I am testing the newer cameras to make sure the merge went fine. I am going to be testing on my camera for 24 hours just to make sure there are no issues since the merge and if not I will mark as ready for review.